### PR TITLE
Add comprehensive model factories and unit tests; update Driver and User factories

### DIFF
--- a/database/factories/ActivityFactory.php
+++ b/database/factories/ActivityFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\Category;
+use App\Models\Destination;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Activity>
+ */
+class ActivityFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->sentence(3),
+            'image' => fake()->imageUrl(),
+            'destination_id' => Destination::factory(),
+            'description' => fake()->paragraph(),
+            'duration' => fake()->numberBetween(1, 8),
+            'duration_unit' => fake()->randomElement(['minutes', 'hours', 'days']),
+            'price' => fake()->randomFloat(2, 5, 500),
+            'category' => fake()->randomElement(Category::cases())->value,
+            'is_active' => true,
+            'start_time' => '09:00:00',
+            'end_time' => '11:00:00',
+            'start_date' => fake()->date(),
+            'end_date' => fake()->date(),
+            'availability' => 'available',
+            'guide_name' => fake()->name(),
+            'guide_language' => 'en',
+            'contact_number' => fake()->phoneNumber(),
+            'requirements' => fake()->sentence(),
+            'difficulty_level' => fake()->randomElement(['easy', 'moderate', 'hard']),
+            'amenities' => ['water', 'equipment'],
+            'address' => fake()->address(),
+            'requires_booking' => fake()->boolean(),
+            'family_friendly' => fake()->randomElement(['yes', 'no']),
+            'pets_allowed' => fake()->boolean(),
+            'highlights' => fake()->sentence(),
+        ];
+    }
+}

--- a/database/factories/DayActivityFactory.php
+++ b/database/factories/DayActivityFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Activity;
+use App\Models\TripDay;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\DayActivity>
+ */
+class DayActivityFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'trip_day_id' => TripDay::factory(),
+            'activity_id' => Activity::factory(),
+            'custom_activity' => fake()->sentence(),
+        ];
+    }
+}

--- a/database/factories/DestinationFactory.php
+++ b/database/factories/DestinationFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Destination>
+ */
+class DestinationFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->city() . ' Destination',
+            'city' => fake()->city(),
+            'country' => fake()->country(),
+            'description' => fake()->paragraph(),
+            'location_details' => fake()->address(),
+            'iata_code' => strtoupper(fake()->lexify('???')),
+            'timezone' => fake()->timezone(),
+            'language' => fake()->languageCode(),
+            'currency' => fake()->currencyCode(),
+            'nearest_airport' => fake()->city() . ' International Airport',
+            'best_time_to_visit' => fake()->monthName(),
+            'emergency_numbers' => '112',
+            'local_tip' => fake()->sentence(),
+        ];
+    }
+}

--- a/database/factories/DestinationImageFactory.php
+++ b/database/factories/DestinationImageFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Destination;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\DestinationImage>
+ */
+class DestinationImageFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'destination_id' => Destination::factory(),
+            'image_url' => fake()->imageUrl(),
+            'is_primary' => fake()->boolean(),
+        ];
+    }
+}

--- a/database/factories/DriverFactory.php
+++ b/database/factories/DriverFactory.php
@@ -39,9 +39,9 @@ class DriverFactory extends Factory
             'date_of_hire' => fake()->date(),
 
             'status' => fake()->randomElement([
-                'completed',
-                'canceled',
-                'pending'
+                'pending',
+                'approved',
+                'rejected',
             ]),
         ];
     }

--- a/database/factories/FavoriteFactory.php
+++ b/database/factories/FavoriteFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Destination;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Favorite>
+ */
+class FavoriteFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'favoritable_type' => Destination::class,
+            'favoritable_id' => Destination::factory(),
+        ];
+    }
+}

--- a/database/factories/HighlightFactory.php
+++ b/database/factories/HighlightFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Destination;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Highlight>
+ */
+class HighlightFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'destination_id' => Destination::factory(),
+            'title' => fake()->sentence(4),
+        ];
+    }
+}

--- a/database/factories/HotelFactory.php
+++ b/database/factories/HotelFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Destination;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Hotel>
+ */
+class HotelFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->company() . ' Hotel',
+            'description' => fake()->paragraph(),
+            'address' => fake()->address(),
+            'city' => fake()->city(),
+            'country' => fake()->country(),
+            'global_rating' => (string) fake()->numberBetween(1, 5),
+            'price_per_night' => fake()->randomFloat(2, 50, 600),
+            'total_rooms' => fake()->numberBetween(10, 250),
+            'destination_id' => Destination::factory(),
+            'stars' => fake()->numberBetween(1, 5),
+            'amenities' => ['wifi', 'parking'],
+            'pets_allowed' => fake()->boolean(),
+            'check_in_time' => '14:00:00',
+            'check_out_time' => '12:00:00',
+            'policies' => fake()->sentence(),
+            'phone_number' => fake()->phoneNumber(),
+            'email' => fake()->safeEmail(),
+            'website' => fake()->url(),
+            'nearby_landmarks' => fake()->sentence(),
+        ];
+    }
+}

--- a/database/factories/HotelImageFactory.php
+++ b/database/factories/HotelImageFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Hotel;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\HotelImage>
+ */
+class HotelImageFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'hotel_id' => Hotel::factory(),
+            'image_url' => fake()->imageUrl(),
+            'is_primary' => fake()->boolean(),
+        ];
+    }
+}

--- a/database/factories/PaymentFactory.php
+++ b/database/factories/PaymentFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Reservation;
+use App\Models\TransportReservation;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Payment>
+ */
+class PaymentFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'reservation_id' => Reservation::factory(),
+            'transport_reservation_id' => null,
+            'user_id' => User::factory(),
+            'amount' => fake()->randomFloat(2, 20, 5000),
+            'status' => fake()->randomElement(['paid', 'pending', 'failed']),
+            'transaction_id' => fake()->uuid(),
+            'payment_date' => now()->toDateString(),
+        ];
+    }
+
+    public function forTransportReservation(): static
+    {
+        return $this->state(fn () => [
+            'transport_reservation_id' => TransportReservation::factory(),
+            'reservation_id' => null,
+        ]);
+    }
+}

--- a/database/factories/ReservationFactory.php
+++ b/database/factories/ReservationFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Hotel;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Reservation>
+ */
+class ReservationFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'hotel_id' => Hotel::factory(),
+            'check_in_date' => now()->toDateString(),
+            'check_out_date' => now()->addDays(2)->toDateString(),
+            'rooms_count' => fake()->numberBetween(1, 3),
+            'guest_count' => fake()->numberBetween(1, 6),
+            'total_price' => fake()->randomFloat(2, 100, 3000),
+            'reservation_status' => fake()->randomElement(['pending', 'confirmed', 'cancelled']),
+        ];
+    }
+}

--- a/database/factories/TransportReservationFactory.php
+++ b/database/factories/TransportReservationFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Driver;
+use App\Models\TransportVehicle;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\TransportReservation>
+ */
+class TransportReservationFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'pickup_location' => fake()->streetAddress(),
+            'dropoff_location' => fake()->streetAddress(),
+            'pickup_datetime' => now()->addHour(),
+            'dropoff_datetime' => now()->addHours(2),
+            'passengers' => fake()->numberBetween(1, 6),
+            'total_price' => fake()->randomFloat(2, 15, 400),
+            'status' => fake()->randomElement(['completed', 'pending', 'cancelled']),
+            'transport_vehicle_id' => TransportVehicle::factory(),
+            'driver_id' => Driver::factory(),
+            'driver_status' => fake()->randomElement(['pending', 'accepted', 'rejected']),
+        ];
+    }
+}

--- a/database/factories/TransportVehicleFactory.php
+++ b/database/factories/TransportVehicleFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Driver;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\TransportVehicle>
+ */
+class TransportVehicleFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'car_model' => fake()->company() . ' ' . fake()->word(),
+            'plate_number' => strtoupper(fake()->bothify('??-####')),
+            'driver_id' => Driver::factory(),
+            'max_passengers' => fake()->numberBetween(2, 8),
+            'base_price' => fake()->randomFloat(2, 20, 150),
+            'price_per_km' => fake()->randomFloat(2, 1, 10),
+            'category' => fake()->randomElement(['economy', 'comfort', 'vip']),
+            'image' => fake()->imageUrl(),
+            'type' => fake()->randomElement(['sedan', 'suv', 'van']),
+        ];
+    }
+}

--- a/database/factories/TripDayFactory.php
+++ b/database/factories/TripDayFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Hotel;
+use App\Models\Trip;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\TripDay>
+ */
+class TripDayFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'trip_id' => Trip::factory(),
+            'day_number' => fake()->numberBetween(1, 14),
+            'hotel_id' => Hotel::factory(),
+            'custom_hotel' => fake()->company() . ' Inn',
+        ];
+    }
+}

--- a/database/factories/TripFactory.php
+++ b/database/factories/TripFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Destination;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Trip>
+ */
+class TripFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'is_ai' => fake()->boolean(),
+            'destination_id' => Destination::factory(),
+            'destination_name' => fake()->city(),
+            'name' => 'Trip to ' . fake()->city(),
+            'description' => fake()->sentence(),
+            'travelers_number' => fake()->numberBetween(1, 8),
+            'budget' => fake()->randomFloat(2, 200, 10000),
+            'start_date' => now()->toDateString(),
+            'end_date' => now()->addDays(5)->toDateString(),
+            'flight_number' => strtoupper(fake()->bothify('??###')),
+            'airline' => fake()->company(),
+            'departure_airport' => strtoupper(fake()->lexify('???')),
+            'arrival_airport' => strtoupper(fake()->lexify('???')),
+            'departure_time' => now(),
+            'arrival_time' => now()->addHours(2),
+            'ai_itinerary' => fake()->paragraph(),
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -25,9 +25,13 @@ class UserFactory extends Factory
     {
         return [
             'name' => fake()->name(),
+            'last_name' => fake()->lastName(),
             'email' => fake()->unique()->safeEmail(),
+            'phone_number' => fake()->phoneNumber(),
+            'country' => fake()->country(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
+            'role' => 'user',
             'remember_token' => Str::random(10),
         ];
     }

--- a/tests/Unit/Models/ActivityTest.php
+++ b/tests/Unit/Models/ActivityTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Activity;
+use App\Models\DayActivity;
+use App\Models\Destination;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ActivityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_activity_relationships_with_counts(): void
+    {
+        $destination = Destination::factory()->create();
+        $activity = Activity::factory()->create(['destination_id' => $destination->id]);
+        DayActivity::factory()->count(2)->create(['activity_id' => $activity->id]);
+
+        $this->assertInstanceOf(BelongsTo::class, $activity->destination());
+        $this->assertInstanceOf(HasMany::class, $activity->dayActivities());
+        $this->assertTrue($activity->destination->is($destination));
+        $this->assertCount(2, $activity->dayActivities);
+    }
+}

--- a/tests/Unit/Models/DayActivityTest.php
+++ b/tests/Unit/Models/DayActivityTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Activity;
+use App\Models\DayActivity;
+use App\Models\TripDay;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DayActivityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_day_activity_relationships_with_bound_models(): void
+    {
+        $tripDay = TripDay::factory()->create();
+        $activity = Activity::factory()->create();
+
+        $dayActivity = DayActivity::factory()->create([
+            'trip_day_id' => $tripDay->id,
+            'activity_id' => $activity->id,
+        ]);
+
+        $this->assertInstanceOf(BelongsTo::class, $dayActivity->tripDay());
+        $this->assertInstanceOf(BelongsTo::class, $dayActivity->activity());
+        $this->assertTrue($dayActivity->tripDay->is($tripDay));
+        $this->assertTrue($dayActivity->activity->is($activity));
+    }
+}

--- a/tests/Unit/Models/DestinationImageTest.php
+++ b/tests/Unit/Models/DestinationImageTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Destination;
+use App\Models\DestinationImage;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DestinationImageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_destination_image_relationship_with_parent(): void
+    {
+        $destination = Destination::factory()->create();
+        $image = DestinationImage::factory()->create(['destination_id' => $destination->id]);
+
+        $this->assertInstanceOf(BelongsTo::class, $image->destination());
+        $this->assertTrue($image->destination->is($destination));
+    }
+}

--- a/tests/Unit/Models/DestinationTest.php
+++ b/tests/Unit/Models/DestinationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Activity;
+use App\Models\Destination;
+use App\Models\DestinationImage;
+use App\Models\Highlight;
+use App\Models\Hotel;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DestinationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_destination_relationships_with_counts(): void
+    {
+        $destination = Destination::factory()->create();
+
+        DestinationImage::factory()->count(2)->create(['destination_id' => $destination->id]);
+        Hotel::factory()->count(2)->create(['destination_id' => $destination->id]);
+        Activity::factory()->count(2)->create(['destination_id' => $destination->id]);
+        Highlight::factory()->count(2)->create(['destination_id' => $destination->id]);
+
+        $this->assertInstanceOf(HasMany::class, $destination->images());
+        $this->assertInstanceOf(HasMany::class, $destination->hotels());
+        $this->assertInstanceOf(MorphMany::class, $destination->favorites());
+        $this->assertInstanceOf(HasMany::class, $destination->activities());
+        $this->assertInstanceOf(HasMany::class, $destination->highlights());
+
+        $this->assertCount(2, $destination->images);
+        $this->assertCount(2, $destination->hotels);
+        $this->assertCount(2, $destination->activities);
+        $this->assertCount(2, $destination->highlights);
+    }
+}

--- a/tests/Unit/Models/DriverTest.php
+++ b/tests/Unit/Models/DriverTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Driver;
+use App\Models\TransportReservation;
+use App\Models\TransportVehicle;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DriverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_driver_relationships_with_counts(): void
+    {
+        $user = User::factory()->create();
+        $driver = Driver::factory()->create(['user_id' => $user->id]);
+
+        TransportVehicle::factory()->create(['driver_id' => $driver->id]);
+        TransportReservation::factory()->count(2)->create(['driver_id' => $driver->id]);
+
+        $this->assertInstanceOf(HasOne::class, $driver->vehicle());
+        $this->assertInstanceOf(HasMany::class, $driver->reservations());
+        $this->assertInstanceOf(BelongsTo::class, $driver->user());
+
+        $this->assertNotNull($driver->vehicle);
+        $this->assertCount(2, $driver->reservations);
+        $this->assertTrue($driver->user->is($user));
+    }
+}

--- a/tests/Unit/Models/FavoriteTest.php
+++ b/tests/Unit/Models/FavoriteTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Destination;
+use App\Models\Favorite;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FavoriteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_favorite_relationships_with_morph_target(): void
+    {
+        $user = User::factory()->create();
+        $destination = Destination::factory()->create();
+
+        $favorite = Favorite::factory()->create([
+            'user_id' => $user->id,
+            'favoritable_type' => Destination::class,
+            'favoritable_id' => $destination->id,
+        ]);
+
+        $this->assertInstanceOf(BelongsTo::class, $favorite->user());
+        $this->assertInstanceOf(MorphTo::class, $favorite->favoritable());
+        $this->assertTrue($favorite->user->is($user));
+        $this->assertTrue($favorite->favoritable->is($destination));
+    }
+}

--- a/tests/Unit/Models/HighlightTest.php
+++ b/tests/Unit/Models/HighlightTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Destination;
+use App\Models\Highlight;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class HighlightTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_highlight_relationship_with_destination(): void
+    {
+        $destination = Destination::factory()->create();
+        $highlight = Highlight::factory()->create(['destination_id' => $destination->id]);
+
+        $this->assertInstanceOf(BelongsTo::class, $highlight->destination());
+        $this->assertTrue($highlight->destination->is($destination));
+    }
+}

--- a/tests/Unit/Models/HotelImageTest.php
+++ b/tests/Unit/Models/HotelImageTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Hotel;
+use App\Models\HotelImage;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class HotelImageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_hotel_image_relationship_with_parent(): void
+    {
+        $hotel = Hotel::factory()->create();
+        $hotelImage = HotelImage::factory()->create(['hotel_id' => $hotel->id]);
+
+        $this->assertInstanceOf(BelongsTo::class, $hotelImage->hotel());
+        $this->assertTrue($hotelImage->hotel->is($hotel));
+    }
+}

--- a/tests/Unit/Models/HotelTest.php
+++ b/tests/Unit/Models/HotelTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Destination;
+use App\Models\Hotel;
+use App\Models\HotelImage;
+use App\Models\Reservation;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class HotelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_hotel_relationships_with_counts(): void
+    {
+        $destination = Destination::factory()->create();
+        $hotel = Hotel::factory()->create(['destination_id' => $destination->id]);
+
+        HotelImage::factory()->count(2)->create(['hotel_id' => $hotel->id]);
+        Reservation::factory()->count(2)->create(['hotel_id' => $hotel->id]);
+
+        $this->assertInstanceOf(BelongsTo::class, $hotel->destination());
+        $this->assertInstanceOf(HasMany::class, $hotel->images());
+        $this->assertInstanceOf(HasMany::class, $hotel->reservations());
+        $this->assertInstanceOf(MorphMany::class, $hotel->favorites());
+
+        $this->assertTrue($hotel->destination->is($destination));
+        $this->assertCount(2, $hotel->images);
+        $this->assertCount(2, $hotel->reservations);
+    }
+}

--- a/tests/Unit/Models/PaymentTest.php
+++ b/tests/Unit/Models/PaymentTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Payment;
+use App\Models\Reservation;
+use App\Models\TransportReservation;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PaymentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_payment_relationships_to_user_and_reservation(): void
+    {
+        $user = User::factory()->create();
+        $reservation = Reservation::factory()->create(['user_id' => $user->id]);
+
+        $payment = Payment::factory()->create([
+            'user_id' => $user->id,
+            'reservation_id' => $reservation->id,
+            'transport_reservation_id' => null,
+        ]);
+
+        $this->assertInstanceOf(BelongsTo::class, $payment->reservation());
+        $this->assertInstanceOf(BelongsTo::class, $payment->user());
+        $this->assertInstanceOf(BelongsTo::class, $payment->transportReservation());
+
+        $this->assertTrue($payment->user->is($user));
+        $this->assertTrue($payment->reservation->is($reservation));
+    }
+
+    public function test_payment_transport_reservation_state(): void
+    {
+        $payment = Payment::factory()->forTransportReservation()->create();
+
+        $this->assertNotNull($payment->transportReservation);
+        $this->assertNull($payment->reservation_id);
+    }
+}

--- a/tests/Unit/Models/ReservationTest.php
+++ b/tests/Unit/Models/ReservationTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Hotel;
+use App\Models\Payment;
+use App\Models\Reservation;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReservationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_reservation_relationships_with_payment(): void
+    {
+        $user = User::factory()->create();
+        $hotel = Hotel::factory()->create();
+
+        $reservation = Reservation::factory()->create([
+            'user_id' => $user->id,
+            'hotel_id' => $hotel->id,
+        ]);
+
+        Payment::factory()->create([
+            'reservation_id' => $reservation->id,
+            'user_id' => $user->id,
+        ]);
+
+        $this->assertInstanceOf(BelongsTo::class, $reservation->hotel());
+        $this->assertInstanceOf(BelongsTo::class, $reservation->user());
+        $this->assertInstanceOf(HasOne::class, $reservation->payment());
+
+        $this->assertTrue($reservation->hotel->is($hotel));
+        $this->assertTrue($reservation->user->is($user));
+        $this->assertNotNull($reservation->payment);
+    }
+}

--- a/tests/Unit/Models/TransportReservationTest.php
+++ b/tests/Unit/Models/TransportReservationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Payment;
+use App\Models\TransportReservation;
+use App\Models\TransportVehicle;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TransportReservationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_transport_reservation_relationships_with_payment(): void
+    {
+        $user = User::factory()->create();
+        $vehicle = TransportVehicle::factory()->create();
+
+        $transportReservation = TransportReservation::factory()->create([
+            'user_id' => $user->id,
+            'transport_vehicle_id' => $vehicle->id,
+        ]);
+
+        Payment::factory()->create([
+            'transport_reservation_id' => $transportReservation->id,
+            'reservation_id' => null,
+            'user_id' => $user->id,
+        ]);
+
+        $this->assertInstanceOf(BelongsTo::class, $transportReservation->user());
+        $this->assertInstanceOf(BelongsTo::class, $transportReservation->vehicle());
+        $this->assertInstanceOf(HasOne::class, $transportReservation->payment());
+        $this->assertInstanceOf(BelongsTo::class, $transportReservation->driver());
+
+        $this->assertTrue($transportReservation->user->is($user));
+        $this->assertTrue($transportReservation->vehicle->is($vehicle));
+        $this->assertNotNull($transportReservation->payment);
+    }
+}

--- a/tests/Unit/Models/TransportVehicleTest.php
+++ b/tests/Unit/Models/TransportVehicleTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Driver;
+use App\Models\TransportReservation;
+use App\Models\TransportVehicle;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TransportVehicleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_transport_vehicle_relationships_with_counts(): void
+    {
+        $driver = Driver::factory()->create();
+        $vehicle = TransportVehicle::factory()->create(['driver_id' => $driver->id]);
+
+        TransportReservation::factory()->count(2)->create(['transport_vehicle_id' => $vehicle->id]);
+
+        $this->assertInstanceOf(HasMany::class, $vehicle->reservations());
+        $this->assertInstanceOf(BelongsTo::class, $vehicle->driver());
+
+        $this->assertTrue($vehicle->driver->is($driver));
+        $this->assertCount(2, $vehicle->reservations);
+    }
+}

--- a/tests/Unit/Models/TripDayTest.php
+++ b/tests/Unit/Models/TripDayTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\DayActivity;
+use App\Models\Hotel;
+use App\Models\Trip;
+use App\Models\TripDay;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TripDayTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_trip_day_relationships_with_counts(): void
+    {
+        $trip = Trip::factory()->create();
+        $hotel = Hotel::factory()->create();
+
+        $tripDay = TripDay::factory()->create([
+            'trip_id' => $trip->id,
+            'hotel_id' => $hotel->id,
+        ]);
+
+        DayActivity::factory()->count(2)->create(['trip_day_id' => $tripDay->id]);
+
+        $this->assertInstanceOf(BelongsTo::class, $tripDay->trip());
+        $this->assertInstanceOf(HasMany::class, $tripDay->activities());
+        $this->assertInstanceOf(BelongsTo::class, $tripDay->hotel());
+        $this->assertCount(2, $tripDay->activities);
+        $this->assertTrue($tripDay->trip->is($trip));
+        $this->assertTrue($tripDay->hotel->is($hotel));
+    }
+}

--- a/tests/Unit/Models/TripTest.php
+++ b/tests/Unit/Models/TripTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Trip;
+use App\Models\TripDay;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TripTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_trip_relationships_with_counts(): void
+    {
+        $user = User::factory()->create();
+        $trip = Trip::factory()->create(['user_id' => $user->id]);
+        TripDay::factory()->count(2)->create(['trip_id' => $trip->id]);
+
+        $this->assertInstanceOf(BelongsTo::class, $trip->user());
+        $this->assertInstanceOf(HasMany::class, $trip->days());
+        $this->assertCount(2, $trip->days);
+        $this->assertTrue($trip->user->is($user));
+    }
+}

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Destination;
+use App\Models\Favorite;
+use App\Models\Payment;
+use App\Models\Reservation;
+use App\Models\TransportReservation;
+use App\Models\Trip;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_trips_relationship_with_count(): void
+    {
+        $user = User::factory()->create();
+        Trip::factory()->count(3)->create(['user_id' => $user->id]);
+
+        $this->assertInstanceOf(HasMany::class, $user->trips());
+        $this->assertCount(3, $user->trips);
+    }
+
+    public function test_user_other_relationships_with_counts(): void
+    {
+        $user = User::factory()->create();
+
+        Reservation::factory()->count(2)->create(['user_id' => $user->id]);
+        Payment::factory()->count(2)->create(['user_id' => $user->id]);
+        TransportReservation::factory()->count(2)->create(['user_id' => $user->id]);
+
+        $destinationOne = Destination::factory()->create();
+        $destinationTwo = Destination::factory()->create();
+
+        Favorite::factory()->create([
+            'user_id' => $user->id,
+            'favoritable_type' => Destination::class,
+            'favoritable_id' => $destinationOne->id,
+        ]);
+
+        Favorite::factory()->create([
+            'user_id' => $user->id,
+            'favoritable_type' => Destination::class,
+            'favoritable_id' => $destinationTwo->id,
+        ]);
+
+        $this->assertInstanceOf(HasMany::class, $user->reservations());
+        $this->assertInstanceOf(HasMany::class, $user->payments());
+        $this->assertInstanceOf(HasMany::class, $user->transport_reservations());
+        $this->assertInstanceOf(HasMany::class, $user->favorites());
+        $this->assertInstanceOf(MorphToMany::class, $user->favoriteDestinations());
+        $this->assertInstanceOf(MorphToMany::class, $user->favoriteHotels());
+        $this->assertInstanceOf(HasOne::class, $user->driver());
+
+        $this->assertCount(2, $user->reservations);
+        $this->assertCount(2, $user->payments);
+        $this->assertCount(2, $user->transport_reservations);
+        $this->assertCount(2, $user->favorites);
+    }
+
+    public function test_user_full_name_accessor(): void
+    {
+        $user = User::factory()->make([
+            'name' => 'Ahmad',
+            'last_name' => 'Khaled',
+        ]);
+
+        $this->assertSame('Ahmad Khaled', $user->full_name);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide reusable model factories to simplify seeding and testing across the domain models.
- Extend existing factories to include missing user fields and normalize driver status values for consistency.
- Add unit tests to assert model relationships and basic collections counts to catch regressions early.

### Description
- Added many new model factories including `Activity`, `DayActivity`, `Destination`, `DestinationImage`, `Favorite`, `Highlight`, `Hotel`, `HotelImage`, `Payment` (with `forTransportReservation` state), `Reservation`, `TransportReservation`, `TransportVehicle`, `TripDay`, `Trip`, and supporting factories referenced by them.
- Updated `DriverFactory` to change available `status` values to `pending`, `approved`, and `rejected` and kept other driver fields unchanged.
- Updated `UserFactory` to include `last_name`, `phone_number`, `country`, and a default `role` of `user` while preserving password handling.
- Added a comprehensive suite of unit tests under `tests/Unit/Models` that exercise relationships and counts for `Activity`, `DayActivity`, `Destination`, `DestinationImage`, `Favorite`, `Highlight`, `Hotel`, `HotelImage`, `Payment`, `Reservation`, `TransportReservation`, `TransportVehicle`, `TripDay`, `Trip`, and `User` models.

### Testing
- Ran the PHPUnit unit test suite with `vendor/bin/phpunit` against the new `tests/Unit/Models` cases.
- All added unit tests executed and passed successfully when run against the updated factories and model relationships.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0c24f50b0832fbcf494348158a734)