### PR TITLE
Add seeders for all factories and update UserFactory defaults

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\UserRole;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -24,14 +25,17 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
+            'name' => fake()->firstName(),
             'last_name' => fake()->lastName(),
             'email' => fake()->unique()->safeEmail(),
-            'phone_number' => fake()->phoneNumber(),
+            'phone_number' => fake()->numerify('##########'),
             'country' => fake()->country(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
-            'role' => 'user',
+            'role' => fake()->randomElement([
+                UserRole::USER->value,
+                UserRole::DRIVER->value,
+            ]),
             'remember_token' => Str::random(10),
         ];
     }

--- a/database/seeders/ActivitySeeder.php
+++ b/database/seeders/ActivitySeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Activity;
+use Illuminate\Database\Seeder;
+
+class ActivitySeeder extends Seeder
+{
+    public function run(): void
+    {
+        Activity::factory(5)->create();
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,25 +2,45 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
-use App\Models\User;
-use Illuminate\Support\Facades\Hash;
 use App\Enums\UserRole;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
 {
     public function run(): void
     {
-        User::create([
-    'name' => 'Admin',
-    'last_name' => 'User',
-    'email' => 'admin@gmail.com',
-    'phone_number' => '0000000000',
-    'role' => 'admin',
-    'country' => 'Morocco', // أو أي قيمة
-    'email_verified_at' => now(),
-    'password' => Hash::make('password'),
-]);
+        User::updateOrCreate(
+            ['email' => 'admin@gmail.com'],
+            [
+                'name' => 'Admin',
+                'last_name' => 'User',
+                'phone_number' => '0000000000',
+                'role' => UserRole::ADMIN->value,
+                'country' => 'Morocco',
+                'email_verified_at' => now(),
+                'password' => Hash::make('password'),
+            ]
+        );
 
+        $this->call([
+            UserSeeder::class,
+            DestinationSeeder::class,
+            DestinationImageSeeder::class,
+            HotelSeeder::class,
+            HotelImageSeeder::class,
+            ActivitySeeder::class,
+            HighlightSeeder::class,
+            TripSeeder::class,
+            TripDaySeeder::class,
+            DayActivitySeeder::class,
+            FavoriteSeeder::class,
+            DriverSeeder::class,
+            TransportVehicleSeeder::class,
+            TransportReservationSeeder::class,
+            ReservationSeeder::class,
+            PaymentSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/DayActivitySeeder.php
+++ b/database/seeders/DayActivitySeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\DayActivity;
+use Illuminate\Database\Seeder;
+
+class DayActivitySeeder extends Seeder
+{
+    public function run(): void
+    {
+        DayActivity::factory(5)->create();
+    }
+}

--- a/database/seeders/DestinationImageSeeder.php
+++ b/database/seeders/DestinationImageSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\DestinationImage;
+use Illuminate\Database\Seeder;
+
+class DestinationImageSeeder extends Seeder
+{
+    public function run(): void
+    {
+        DestinationImage::factory(5)->create();
+    }
+}

--- a/database/seeders/DestinationSeeder.php
+++ b/database/seeders/DestinationSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Destination;
+use Illuminate\Database\Seeder;
+
+class DestinationSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Destination::factory(5)->create();
+    }
+}

--- a/database/seeders/DriverSeeder.php
+++ b/database/seeders/DriverSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Driver;
+use Illuminate\Database\Seeder;
+
+class DriverSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Driver::factory(5)->create();
+    }
+}

--- a/database/seeders/FavoriteSeeder.php
+++ b/database/seeders/FavoriteSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Favorite;
+use Illuminate\Database\Seeder;
+
+class FavoriteSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Favorite::factory(5)->create();
+    }
+}

--- a/database/seeders/HighlightSeeder.php
+++ b/database/seeders/HighlightSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Highlight;
+use Illuminate\Database\Seeder;
+
+class HighlightSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Highlight::factory(5)->create();
+    }
+}

--- a/database/seeders/HotelImageSeeder.php
+++ b/database/seeders/HotelImageSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\HotelImage;
+use Illuminate\Database\Seeder;
+
+class HotelImageSeeder extends Seeder
+{
+    public function run(): void
+    {
+        HotelImage::factory(5)->create();
+    }
+}

--- a/database/seeders/HotelSeeder.php
+++ b/database/seeders/HotelSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Hotel;
+use Illuminate\Database\Seeder;
+
+class HotelSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Hotel::factory(5)->create();
+    }
+}

--- a/database/seeders/PaymentSeeder.php
+++ b/database/seeders/PaymentSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Payment;
+use Illuminate\Database\Seeder;
+
+class PaymentSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Payment::factory(5)->create();
+    }
+}

--- a/database/seeders/ReservationSeeder.php
+++ b/database/seeders/ReservationSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Reservation;
+use Illuminate\Database\Seeder;
+
+class ReservationSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Reservation::factory(5)->create();
+    }
+}

--- a/database/seeders/TransportReservationSeeder.php
+++ b/database/seeders/TransportReservationSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\TransportReservation;
+use Illuminate\Database\Seeder;
+
+class TransportReservationSeeder extends Seeder
+{
+    public function run(): void
+    {
+        TransportReservation::factory(5)->create();
+    }
+}

--- a/database/seeders/TransportVehicleSeeder.php
+++ b/database/seeders/TransportVehicleSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\TransportVehicle;
+use Illuminate\Database\Seeder;
+
+class TransportVehicleSeeder extends Seeder
+{
+    public function run(): void
+    {
+        TransportVehicle::factory(5)->create();
+    }
+}

--- a/database/seeders/TripDaySeeder.php
+++ b/database/seeders/TripDaySeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\TripDay;
+use Illuminate\Database\Seeder;
+
+class TripDaySeeder extends Seeder
+{
+    public function run(): void
+    {
+        TripDay::factory(5)->create();
+    }
+}

--- a/database/seeders/TripSeeder.php
+++ b/database/seeders/TripSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Trip;
+use Illuminate\Database\Seeder;
+
+class TripSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Trip::factory(5)->create();
+    }
+}

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class UserSeeder extends Seeder
+{
+    public function run(): void
+    {
+        User::factory(5)->create();
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an easy way to populate the database with sample data for every model/factory and ensure the `User` factory produces consistent realistic values.
- Make `DatabaseSeeder` idempotent for the admin user and orchestrate all created seeders for a single full-seed entrypoint.

### Description
- Updated `UserFactory` to generate cleaner sample data (`firstName`, numeric 10-digit `phone_number`) and to use enum-backed role values (`UserRole::USER` and `UserRole::DRIVER`) instead of a hardcoded string.
- Added dedicated seeder files for each factory: `UserSeeder`, `DestinationSeeder`, `DestinationImageSeeder`, `HotelSeeder`, `HotelImageSeeder`, `ActivitySeeder`, `HighlightSeeder`, `TripSeeder`, `TripDaySeeder`, `DayActivitySeeder`, `FavoriteSeeder`, `DriverSeeder`, `TransportVehicleSeeder`, `TransportReservationSeeder`, `ReservationSeeder`, and `PaymentSeeder`, each calling `::factory(5)->create()`.
- Updated `DatabaseSeeder` to `updateOrCreate` a stable admin user and to call all new seeders in order via `$this->call([...])`.

### Testing
- Linted updated files with `php -l` for `database/seeders/DatabaseSeeder.php`, `database/factories/UserFactory.php`, and all files in `database/seeders/*Seeder.php`, and the lint pass succeeded for all files.
- Attempted to run `php artisan db:seed --force`, but it failed due to missing project dependencies (`vendor/autoload.php` not present) in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0e8304740832f98d689781f456cbe)