### PR TITLE
Make driver request/processing synchronous in critical flows and add fallback driver ranking

### DIFF
--- a/app/Domain/TransportReservation/DriverChain/SendToNextDriverHandler.php
+++ b/app/Domain/TransportReservation/DriverChain/SendToNextDriverHandler.php
@@ -16,7 +16,7 @@ class SendToNextDriverHandler extends DriverRequestHandler
         }
 
         //send request to the handler(driver) u
-        SendBookingRequestToDriverJob::dispatch($reservation->id, $rankedDriverIds[$index], $rankedDriverIds, $index);
+        SendBookingRequestToDriverJob::dispatchSync($reservation->id, $rankedDriverIds[$index], $rankedDriverIds, $index);
 
         return true;
     }

--- a/app/Http/Controllers/VehicleOrderController.php
+++ b/app/Http/Controllers/VehicleOrderController.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 use App\Http\Requests\VehicleOrderRequest;
+use App\Jobs\ProcessNextDriverInChainJob;
 use App\Jobs\ProcessReservationDriverMatchingJob;
+use App\Models\BookingRequest;
 use App\Models\TransportReservation;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -34,7 +36,7 @@ class VehicleOrderController extends Controller
             'driver_status' => 'pending',
         ]);
 
-        ProcessReservationDriverMatchingJob::dispatch($reservation->id);
+        ProcessReservationDriverMatchingJob::dispatchSync($reservation->id);
 
         return redirect()->route('vehicle.searching', $reservation);
     }
@@ -49,6 +51,26 @@ class VehicleOrderController extends Controller
     public function status(TransportReservation $reservation)
     {
         abort_unless($reservation->user_id === Auth::id(), 403);
+
+        if ($reservation->status === 'pending_driver') {
+            $pendingRequest = BookingRequest::query()
+                ->where('reservation_id', $reservation->id)
+                ->where('status', 'pending')
+                ->latest('id')
+                ->first();
+
+            if ($pendingRequest && $pendingRequest->expires_at && $pendingRequest->expires_at->isPast()) {
+                $pendingRequest->update(['status' => 'expired']);
+
+                ProcessNextDriverInChainJob::dispatchSync(
+                    $reservation->id,
+                    $reservation->ranked_driver_ids ?? [],
+                    array_search($pendingRequest->driver_id, $reservation->ranked_driver_ids ?? [], true) + 1,
+                );
+
+                $reservation->refresh();
+            }
+        }
 
         $redirectUrl = null;
         if ($reservation->status === 'driver_assigned') {

--- a/app/Jobs/SendBookingRequestToDriverJob.php
+++ b/app/Jobs/SendBookingRequestToDriverJob.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Queue;
 
 class SendBookingRequestToDriverJob implements ShouldQueue
 {
@@ -44,6 +45,9 @@ class SendBookingRequestToDriverJob implements ShouldQueue
             $driver->user->notify(new DriverBookingRequestNotification($reservation));
         }
 
-        CheckBookingRequestTimeoutJob::dispatch($bookingRequest->id, $this->rankedDriverIds, $this->currentIndex)->delay($bookingRequest->expires_at);
+        if (Queue::getDefaultDriver() !== 'sync') {
+            CheckBookingRequestTimeoutJob::dispatch($bookingRequest->id, $this->rankedDriverIds, $this->currentIndex)
+                ->delay($bookingRequest->expires_at);
+        }
     }
 }

--- a/app/Services/TransportReservation/DriverRankingService.php
+++ b/app/Services/TransportReservation/DriverRankingService.php
@@ -50,6 +50,15 @@ class DriverRankingService
             ->values()
             ->all();
 
+        if (empty($driverIds)) {
+            // Fallback: if no shift assignment matches, still try approved drivers
+            // so booking requests can continue instead of immediate cancellation.
+            $driverIds = Driver::query()
+                ->whereIn('status', ['approved', 'Approved'])
+                ->pluck('id')
+                ->all();
+        }
+
         $drivers = Driver::query()->whereIn('id', $driverIds)->get();
 
         return $this->strategy->rank($drivers)->pluck('id')->all();


### PR DESCRIPTION
### Motivation

- Ensure booking request and reservation driver-matching flows proceed synchronously in contexts where asynchronous queues would impede immediate processing or timeouts. 
- Prevent scheduling a delayed timeout job when the queue driver is running in `sync` mode to avoid missed or double-handled expiration logic. 
- Provide a fallback list of drivers when no shift assignments match so reservations are not immediately cancelled.

### Description

- Replace `SendBookingRequestToDriverJob::dispatch(...)` with `::dispatchSync(...)` in `SendToNextDriverHandler` so the send-to-driver action runs immediately. 
- Replace `ProcessReservationDriverMatchingJob::dispatch(...)` with `::dispatchSync(...)` in `VehicleOrderController::store` to perform initial matching synchronously. 
- In `VehicleOrderController::status` add logic to detect an expired pending `BookingRequest`, mark it `expired`, and synchronously dispatch `ProcessNextDriverInChainJob::dispatchSync(...)` to advance the chain, then refresh the `TransportReservation`. 
- In `SendBookingRequestToDriverJob` only schedule `CheckBookingRequestTimeoutJob` with a delay when the queue driver is not `sync` by checking `Queue::getDefaultDriver()`. 
- In `DriverRankingService` add a fallback to select drivers with `status` in `['approved','Approved']` if no drivers matched shift assignments so booking requests can continue.

### Testing

- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a60194e218832f9d78a12d211eecee)