### PR TITLE
Add Laravel request validators for trip-related models

### DIFF
--- a/app/Http/Requests/ActivityAssignmentRequest.php
+++ b/app/Http/Requests/ActivityAssignmentRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ActivityAssignmentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'day_activity_id' => 'required|exists:day_activities,id',
+            'guide_id' => 'required|exists:guides,id',
+            'status' => 'nullable|string|in:assigned,completed,cancelled',
+        ];
+    }
+}

--- a/app/Http/Requests/DayActivityRequest.php
+++ b/app/Http/Requests/DayActivityRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DayActivityRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'trip_day_id' => 'required|exists:trip_days,id',
+            'activity_id' => 'required|exists:activities,id',
+            'start_time' => 'nullable|date_format:H:i',
+            'end_time' => 'nullable|date_format:H:i|after_or_equal:start_time',
+            'notes' => 'nullable|string',
+        ];
+    }
+}

--- a/app/Http/Requests/GuideAssignmentRequest.php
+++ b/app/Http/Requests/GuideAssignmentRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GuideAssignmentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'trip_id' => 'required|exists:trips,id',
+            'guide_id' => 'required|exists:guides,id',
+            'status' => 'nullable|string|in:pending,accepted,rejected,cancelled',
+        ];
+    }
+}

--- a/app/Http/Requests/GuideAvailabilityRequest.php
+++ b/app/Http/Requests/GuideAvailabilityRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GuideAvailabilityRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'guide_id' => 'required|exists:guides,id',
+            'date' => 'required|date',
+            'start_time' => 'required|date_format:H:i',
+            'end_time' => 'required|date_format:H:i|after:start_time',
+        ];
+    }
+}

--- a/app/Http/Requests/TripDayRequest.php
+++ b/app/Http/Requests/TripDayRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TripDayRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'trip_id' => 'required|exists:trips,id',
+            'day_number' => 'required|integer|min:1',
+            'title' => 'nullable|string|max:255',
+            'description' => 'nullable|string',
+            'highlights' => 'nullable|array',
+            'highlights.*' => 'string|max:255',
+            'hotel_id' => 'nullable|exists:hotels,id',
+        ];
+    }
+}

--- a/app/Http/Requests/TripExcludeRequest.php
+++ b/app/Http/Requests/TripExcludeRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TripExcludeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'trip_package_id' => 'required|exists:trip_packages,id',
+            'content' => 'required|string|max:255',
+        ];
+    }
+}

--- a/app/Http/Requests/TripHighlightRequest.php
+++ b/app/Http/Requests/TripHighlightRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TripHighlightRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'trip_package_id' => 'nullable|exists:trip_packages,id',
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+        ];
+    }
+}

--- a/app/Http/Requests/TripImageRequest.php
+++ b/app/Http/Requests/TripImageRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TripImageRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'trip_id' => 'required|exists:trips,id',
+            'image_path' => 'required|string|max:2048',
+            'is_cover' => 'nullable|boolean',
+        ];
+    }
+}

--- a/app/Http/Requests/TripIncludeRequest.php
+++ b/app/Http/Requests/TripIncludeRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TripIncludeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'trip_package_id' => 'required|exists:trip_packages,id',
+            'content' => 'required|string|max:255',
+        ];
+    }
+}

--- a/app/Http/Requests/TripPackageHotelRequest.php
+++ b/app/Http/Requests/TripPackageHotelRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TripPackageHotelRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'trip_package_id' => 'required|exists:trip_packages,id',
+            'hotel_id' => 'required|exists:hotels,id',
+            'room_type' => 'nullable|string|max:255',
+            'amenities' => 'nullable|array',
+            'amenities.*' => 'string|max:255',
+            'meal_plan' => 'nullable|string|max:255',
+        ];
+    }
+}

--- a/app/Http/Requests/TripPackageInfoRequest.php
+++ b/app/Http/Requests/TripPackageInfoRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TripPackageInfoRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'trip_package_id' => 'required|exists:trip_packages,id',
+            'content' => 'required|string',
+        ];
+    }
+}

--- a/app/Http/Requests/TripPackageRequest.php
+++ b/app/Http/Requests/TripPackageRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TripPackageRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'trip_id' => 'required|exists:trips,id',
+            'name' => 'required|string|max:255',
+            'price' => 'required|numeric|min:0',
+        ];
+    }
+}

--- a/app/Http/Requests/TripReservationRequest.php
+++ b/app/Http/Requests/TripReservationRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TripReservationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'user_id' => 'required|exists:users,id',
+            'day_activity_id' => 'required|exists:day_activities,id',
+            'guide_id' => 'required|exists:guides,id',
+            'status' => 'nullable|string|in:assigned,completed,cancelled',
+        ];
+    }
+}

--- a/app/Http/Requests/TripScheduleRequest.php
+++ b/app/Http/Requests/TripScheduleRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TripScheduleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'trip_id' => 'required|exists:trips,id',
+            'start_date' => 'required|date',
+            'end_date' => 'required|date|after_or_equal:start_date',
+            'booking_deadline' => 'nullable|date|before_or_equal:start_date',
+            'available_seats' => 'nullable|integer|min:0',
+            'price_modifier' => 'nullable|numeric|between:-999.99,999.99',
+            'status' => 'nullable|string|in:available,full,cancelled',
+        ];
+    }
+}

--- a/app/Http/Requests/TripTransportRequest.php
+++ b/app/Http/Requests/TripTransportRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TripTransportRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'trip_id' => 'required|exists:trips,id',
+            'transport_vehicle_id' => 'required|exists:transport_vehicles,id',
+            'driver_id' => 'nullable|exists:drivers,id',
+            'transport_type' => 'required|string|max:255',
+            'departure_time' => 'nullable|date_format:H:i',
+            'return_time' => 'nullable|date_format:H:i|after_or_equal:departure_time',
+            'notes' => 'nullable|string',
+        ];
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce validation for newly added trip planning entities to centralize request rules and enforce data integrity at the controller boundary.

### Description
- Added 15 new `FormRequest` classes under `app/Http/Requests` for: `TripTransport`, `TripSchedule`, `TripReservation`, `TripPackageInfo`, `TripPackageHotel`, `TripPackage`, `TripInclude`, `TripImage`, `TripHighlight`, `TripExclude`, `TripDay`, `GuideAssignment`, `GuideAvailability`, `ActivityAssignment`, and `DayActivity`.
- Each request implements `authorize(): true` and includes validation rules covering foreign-key existence, date/time formats, enum-like `status` constraints, numeric ranges, and array/JSON field validation where applicable.
- Files created and committed with message `Add FormRequest classes for trip planning entities`.

### Testing
- Ran syntax checks: `php -l` on all new request files and confirmed: "No syntax errors detected" for each file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc49a9223483308d7f4d29bc24744c)