### PR TITLE
AI trip generation: use DB catalog, Groq integration, prompt strategies, and persist itinerary

### DIFF
--- a/app/Http/Controllers/AiTripController.php
+++ b/app/Http/Controllers/AiTripController.php
@@ -2,75 +2,111 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
-use App\Services\GroqTripPlannerService;
+use App\Models\DayActivity;
+use App\Models\Destination;
 use App\Models\Trip;
-use Carbon\Carbon; 
+use App\Models\TripDay;
+use App\Services\GroqTripPlannerService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class AiTripController extends Controller
 {
-    protected $groqService;
-
-    public function __construct(GroqTripPlannerService $groqService)
+    public function __construct(protected GroqTripPlannerService $groqService)
     {
-        $this->groqService = $groqService;
     }
 
     public function create()
     {
-        return view('trips.ai.create');
+        $destinations = Destination::query()->orderBy('name')->get(['id', 'name', 'city', 'country']);
+
+        return view('trips.ai.create', compact('destinations'));
     }
 
     public function generate(Request $request)
     {
-        
         $validated = $request->validate([
+            'destination_id' => 'required|exists:destinations,id',
             'description' => 'required|string|max:1000',
             'travelers_number' => 'required|integer|min:1',
-            'budget' => 'nullable|numeric',
-            'duration' => 'required|integer|min:1',
+            'budget' => 'nullable|numeric|min:0',
+            'duration' => 'required|integer|min:1|max:30',
             'start_date' => 'nullable|date',
             'end_date' => 'nullable|date|after_or_equal:start_date',
             'language' => 'nullable|in:en,ar',
         ]);
 
-        
-       
-        $startDate = $validated['start_date'] ?? now()->toDateString();
-        
-       
-        if (empty($validated['end_date'])) {
-            $endDate = Carbon::parse($startDate)->addDays($validated['duration'] - 1)->toDateString();
-        } else {
-            $endDate = $validated['end_date'];
+        $language = $validated['language'] ?? 'en';
+        $plan = $this->groqService->generateTripPlan($validated, $language);
+
+        if (! $plan) {
+            return back()->withErrors(['api_error' => 'Failed to generate trip from Groq API.']);
         }
 
-        
-        $language = $validated['language'] ?? 'en';
-        $tripPlan = $this->groqService->generateTripPlan($validated, $language);
+        $trip = DB::transaction(function () use ($validated, $plan) {
+            $name = Str::limit($plan['trip_name'] ?: $validated['description'], 120, '');
+            $slugBase = Str::slug($name ?: 'ai-trip');
 
-        
-        if ($tripPlan) {
             $trip = Trip::create([
-                'user_id' => auth()->id(),
-                'is_ai' => true,
-                'name' => 'AI Trip: ' . substr($validated['description'], 0, 30) . '...',
-                'description' => $validated['description'],
-                'travelers_number' => $validated['travelers_number'],
-                'budget' => $validated['budget'],
-                'start_date' => $startDate,
-                'end_date' => $endDate,
-                'ai_itinerary' => $tripPlan,
+                'destination_id' => $validated['destination_id'],
+                'name' => $name,
+                'slug' => $this->nextUniqueSlug($slugBase),
+                'duration_days' => (int) $validated['duration'],
+                'category' => 'ai-generated',
+                'max_participants' => (int) $validated['travelers_number'],
+                // Meeting point is admin-managed (OpenStreetMap + geocoding flow), not AI-managed.
+                'meeting_point_description' => null,
+                'meeting_point_address' => null,
+                'is_ai_generated' => true,
+                'ai_prompt' => $validated['description'],
+                'status' => 'draft',
             ]);
 
-            return redirect()->route('ai.show', $trip->id)->with('success', 'Your AI trip has been generated and saved!');
-        }
+            foreach ($plan['days'] as $day) {
+                $tripDay = TripDay::create([
+                    'trip_id' => $trip->id,
+                    'day_number' => (int) $day['day_number'],
+                    'title' => $day['title'],
+                    'description' => $day['description'],
+                    'highlights' => [],
+                    'hotel_id' => $day['hotel_id'] ?? null,
+                ]);
 
-        return back()->withErrors(['api_error' => 'Failed to generate trip. Please check your API key.']);
+                foreach ($day['activities'] as $activity) {
+                    DayActivity::create([
+                        'trip_day_id' => $tripDay->id,
+                        'activity_id' => (int) $activity['activity_id'],
+                        'start_time' => $activity['start_time'] ?? null,
+                        'end_time' => $activity['end_time'] ?? null,
+                        'notes' => $activity['notes'] ?? null,
+                    ]);
+                }
+            }
+
+            return $trip;
+        });
+
+        return redirect()->route('ai.show', $trip->id)->with('success', 'Your AI trip has been generated and saved!');
     }
 
     public function show(Trip $trip)
     {
+        $trip->load(['destination', 'days.activities.activity', 'days.hotel']);
+
         return view('trips.ai.show', compact('trip'));
+    }
+
+    protected function nextUniqueSlug(string $slugBase): string
+    {
+        $slug = $slugBase ?: 'ai-trip';
+        $counter = 1;
+
+        while (Trip::query()->where('slug', $slug)->exists()) {
+            $slug = $slugBase . '-' . $counter;
+            $counter++;
+        }
+
+        return $slug;
     }
 }

--- a/app/Services/AiTrip/Contracts/TripPromptStrategy.php
+++ b/app/Services/AiTrip/Contracts/TripPromptStrategy.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Services\AiTrip\Contracts;
+
+interface TripPromptStrategy
+{
+    public function language(): string;
+
+    public function systemMessage(): string;
+
+    public function userMessage(array $tripData, array $catalog): string;
+}

--- a/app/Services/AiTrip/Prompts/ArabicTripPromptStrategy.php
+++ b/app/Services/AiTrip/Prompts/ArabicTripPromptStrategy.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Services\AiTrip\Prompts;
+
+use App\Services\AiTrip\Contracts\TripPromptStrategy;
+
+class ArabicTripPromptStrategy implements TripPromptStrategy
+{
+    public function language(): string
+    {
+        return 'ar';
+    }
+
+    public function systemMessage(): string
+    {
+        return 'أنت مخطط رحلات ويجب أن تلتزم فقط ببيانات الكتالوج المرسلة من قاعدة البيانات. ممنوع اختراع أي بيانات. أعد JSON صالح فقط.';
+    }
+
+    public function userMessage(array $tripData, array $catalog): string
+    {
+        $catalogJson = json_encode($catalog, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+
+        return <<<PROMPT
+أنشئ خطة رحلة لمدة {$tripData['duration']} يوم باللغة العربية بالاعتماد فقط على معرفات البيانات الموجودة في الكتالوج.
+
+مدخلات المستخدم:
+- destination_id: {$tripData['destination_id']}
+- الوصف: {$tripData['description']}
+- عدد المسافرين: {$tripData['travelers_number']}
+- الميزانية: {$tripData['budget']}
+
+قواعد صارمة:
+1) استخدم فقط destination_id و hotel_id و activity_id الموجودة في الكتالوج.
+2) ممنوع توليد بيانات الباقات مثل includes/excludes/highlights/info أو بيانات النقل trip_transports.
+3) ممنوع توليد meeting_point_description أو meeting_point_address لأنها تدار من الأدمن عبر الخريطة وخدمة geocoding.
+4) إذا لم تجد خياراً مناسباً لا تخترع بيانات، وتجاوز العنصر.
+5) ركّز على أحدث البيانات (updated_at الأحدث).
+6) يجب أن يكون الخرج JSON مطابق تماماً للبنية التالية:
+{
+  "trip_name": "string",
+  "trip_description": "string",
+  "days": [
+    {
+      "day_number": 1,
+      "title": "string",
+      "description": "string",
+      "hotel_id": 1,
+      "activities": [
+        {
+          "activity_id": 1,
+          "start_time": "09:00",
+          "end_time": "11:00",
+          "notes": "string"
+        }
+      ]
+    }
+  ],
+  "markdown_summary": "string"
+}
+
+الكتالوج:
+{$catalogJson}
+PROMPT;
+    }
+}

--- a/app/Services/AiTrip/Prompts/EnglishTripPromptStrategy.php
+++ b/app/Services/AiTrip/Prompts/EnglishTripPromptStrategy.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Services\AiTrip\Prompts;
+
+use App\Services\AiTrip\Contracts\TripPromptStrategy;
+
+class EnglishTripPromptStrategy implements TripPromptStrategy
+{
+    public function language(): string
+    {
+        return 'en';
+    }
+
+    public function systemMessage(): string
+    {
+        return 'You are a trip planner that MUST only use the provided database catalog. Never invent destinations, hotels, or activities. Return valid JSON only.';
+    }
+
+    public function userMessage(array $tripData, array $catalog): string
+    {
+        $catalogJson = json_encode($catalog, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+
+        return <<<PROMPT
+Create a {$tripData['duration']}-day trip plan in English using only IDs and names that exist in the catalog below.
+
+User input:
+- Destination ID: {$tripData['destination_id']}
+- Description: {$tripData['description']}
+- Travelers: {$tripData['travelers_number']}
+- Budget: {$tripData['budget']}
+
+STRICT RULES:
+1) Use ONLY destination_id, hotel_id, and activity_id values from the catalog.
+2) Do NOT generate trip packages data: includes, excludes, package highlights, package info, or transport assignments.
+3) Do NOT generate meeting point fields (meeting_point_description / meeting_point_address); those are admin-managed via map/geocoding.
+4) If a requested item does not exist, skip it and keep the plan realistic.
+5) Prefer newest records (higher updated_at values in the catalog).
+6) Output must be JSON matching this shape exactly:
+{
+  "trip_name": "string",
+  "trip_description": "string",
+  "days": [
+    {
+      "day_number": 1,
+      "title": "string",
+      "description": "string",
+      "hotel_id": 1,
+      "activities": [
+        {
+          "activity_id": 1,
+          "start_time": "09:00",
+          "end_time": "11:00",
+          "notes": "string"
+        }
+      ]
+    }
+  ],
+  "markdown_summary": "string"
+}
+
+Catalog:
+{$catalogJson}
+PROMPT;
+    }
+}

--- a/app/Services/AiTrip/TripCatalogService.php
+++ b/app/Services/AiTrip/TripCatalogService.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Services\AiTrip;
+
+use App\Models\Destination;
+
+class TripCatalogService
+{
+    public function buildCatalog(int $destinationId): array
+    {
+        $destination = Destination::query()
+            ->with([
+                'hotels' => fn ($query) => $query->orderByDesc('updated_at')->limit(20),
+                'activities' => fn ($query) => $query->where('is_active', true)->orderByDesc('updated_at')->limit(40),
+            ])
+            ->findOrFail($destinationId);
+
+        return [
+            'destination' => [
+                'id' => $destination->id,
+                'name' => $destination->name,
+                'city' => $destination->city,
+                'country' => $destination->country,
+                'updated_at' => optional($destination->updated_at)?->toDateTimeString(),
+            ],
+            'hotels' => $destination->hotels->map(fn ($hotel) => [
+                'id' => $hotel->id,
+                'name' => $hotel->name,
+                'price_per_night' => $hotel->price_per_night,
+                'stars' => $hotel->stars,
+                'updated_at' => optional($hotel->updated_at)?->toDateTimeString(),
+            ])->values()->all(),
+            'activities' => $destination->activities->map(fn ($activity) => [
+                'id' => $activity->id,
+                'name' => $activity->name,
+                'price' => $activity->price,
+                'category' => $activity->category,
+                'duration' => $activity->duration,
+                'duration_unit' => $activity->duration_unit,
+                'updated_at' => optional($activity->updated_at)?->toDateTimeString(),
+            ])->values()->all(),
+        ];
+    }
+}

--- a/app/Services/GroqTripPlannerService.php
+++ b/app/Services/GroqTripPlannerService.php
@@ -2,42 +2,45 @@
 
 namespace App\Services;
 
+use App\Services\AiTrip\Contracts\TripPromptStrategy;
+use App\Services\AiTrip\Prompts\ArabicTripPromptStrategy;
+use App\Services\AiTrip\Prompts\EnglishTripPromptStrategy;
+use App\Services\AiTrip\TripCatalogService;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 class GroqTripPlannerService
 {
-    protected $apiKey;
-    protected $endpoint = 'https://api.groq.com/openai/v1/chat/completions';
-    protected $model = 'llama-3.3-70b-versatile';
+    protected string $apiKey;
+    protected string $endpoint = 'https://api.groq.com/openai/v1/chat/completions';
+    protected string $model = 'llama-3.3-70b-versatile';
 
-    public function __construct()
+    /** @var array<string, TripPromptStrategy> */
+    protected array $promptStrategies;
+
+    public function __construct(protected TripCatalogService $catalogService)
     {
-        $this->apiKey = env('GROQ_API_KEY');
+        $this->apiKey = (string) env('GROQ_API_KEY', '');
+
+        $strategies = [
+            new EnglishTripPromptStrategy(),
+            new ArabicTripPromptStrategy(),
+        ];
+
+        $this->promptStrategies = collect($strategies)
+            ->keyBy(fn (TripPromptStrategy $strategy) => $strategy->language())
+            ->all();
     }
 
-    /**
-     * Generates a trip plan using Groq API.
-     *
-     * @param array $tripData
-     * @param string $language 'en' or 'ar'
-     * @return string|null The generated trip plan text or null on failure.
-     */
-    public function generateTripPlan(array $tripData, string $language = 'en'): ?string
+    public function generateTripPlan(array $tripData, string $language = 'en'): ?array
     {
-        if (!$this->apiKey) {
+        if (blank($this->apiKey)) {
             Log::error('Groq API Key is missing.');
             return null;
         }
 
-        // Build the prompt based on the required language
-        if ($language === 'ar') {
-            $prompt = $this->buildArabicPrompt($tripData);
-            $systemMessage = 'أنت مخطط رحلات سياحية محترف. مهمتك هي إنشاء خطط رحلات مفصلة ومنظمة بشكل جيد باللغة العربية.';
-        } else {
-            $prompt = $this->buildEnglishPrompt($tripData);
-            $systemMessage = 'You are a professional travel planner. Your task is to create detailed and well-organized trip itineraries in English.';
-        }
+        $strategy = $this->promptStrategies[$language] ?? $this->promptStrategies['en'];
+        $catalog = $this->catalogService->buildCatalog((int) $tripData['destination_id']);
 
         try {
             $response = Http::withHeaders([
@@ -46,60 +49,73 @@ class GroqTripPlannerService
             ])->post($this->endpoint, [
                 'model' => $this->model,
                 'messages' => [
-                    [
-                        'role' => 'system',
-                        'content' => $systemMessage
-                    ],
-                    [
-                        'role' => 'user',
-                        'content' => $prompt
-                    ]
+                    ['role' => 'system', 'content' => $strategy->systemMessage()],
+                    ['role' => 'user', 'content' => $strategy->userMessage($tripData, $catalog)],
                 ],
-                'temperature' => 0.7,
-                'max_tokens' => 3000,
+                'temperature' => 0.2,
+                'max_tokens' => 3500,
+                'response_format' => ['type' => 'json_object'],
             ]);
 
-            if ($response->successful()) {
-                $data = $response->json();
-                return $data['choices'][0]['message']['content'] ?? null;
-            } else {
+            if (! $response->successful()) {
                 Log::error('Groq API Request Failed', ['status' => $response->status(), 'body' => $response->body()]);
                 return null;
             }
 
-        } catch (\Exception $e) {
+            $content = $response->json('choices.0.message.content');
+
+            if (! is_string($content) || blank($content)) {
+                return null;
+            }
+
+            $decoded = json_decode($content, true);
+
+            if (! is_array($decoded)) {
+                return null;
+            }
+
+            return $this->sanitizeAgainstCatalog($decoded, $catalog);
+        } catch (\Throwable $e) {
             Log::error('Groq API Exception', ['message' => $e->getMessage()]);
             return null;
         }
     }
 
-    protected function buildEnglishPrompt(array $data): string
+    protected function sanitizeAgainstCatalog(array $plan, array $catalog): array
     {
-        return "I want to plan a trip. Please create a detailed and well-organized trip itinerary in Markdown format.
-        - Trip Description: {$data['description']}
-        - Duration: {$data['duration']} days
-        - Number of Travelers: {$data['travelers_number']}
-        - Estimated Budget: " . ($data['budget'] ? "\${$data['budget']}" : "Not specified") . "
-        
-        **Requirements:**
-        1. The plan must be divided by day (Day 1, Day 2, etc.).
-        2. For each day, specify suggested activities (Morning, Afternoon, Evening).
-        3. The response must be in clear, professional English.
-        4. The response must be in clean, readable Markdown format (use headings and lists).";
-    }
+        $allowedHotelIds = collect($catalog['hotels'])->pluck('id')->map(fn ($id) => (int) $id)->all();
+        $allowedActivityIds = collect($catalog['activities'])->pluck('id')->map(fn ($id) => (int) $id)->all();
 
-    protected function buildArabicPrompt(array $data): string
-    {
-        return "أنا أرغب في تخطيط رحلة. الرجاء إنشاء خطة رحلة مفصلة ومنظمة بتنسيق Markdown.
-        - وصف الرحلة: {$data['description']}
-        - عدد الأيام: {$data['duration']} أيام
-        - عدد المسافرين: {$data['travelers_number']}
-        - الميزانية التقديرية: " . ($data['budget'] ? "{$data['budget']}$" : "غير محددة") . "
-        
-        **المتطلبات:**
-        1. يجب أن تكون الخطة مقسمة حسب الأيام (اليوم الأول، اليوم الثاني، إلخ).
-        2. لكل يوم، يجب تحديد الأنشطة المقترحة (صباحاً، ظهراً، مساءً).
-        3. يجب أن يكون الرد باللغة العربية الفصحى فقط.
-        4. يجب أن يكون الرد بتنسيق Markdown واضح وسهل القراءة (استخدمي العناوين والقوائم).";
+        $plan['days'] = collect($plan['days'] ?? [])
+            ->map(function ($day, $index) use ($allowedHotelIds, $allowedActivityIds) {
+                $activities = collect($day['activities'] ?? [])
+                    ->filter(fn ($activity) => in_array((int) ($activity['activity_id'] ?? 0), $allowedActivityIds, true))
+                    ->map(fn ($activity) => [
+                        'activity_id' => (int) $activity['activity_id'],
+                        'start_time' => $activity['start_time'] ?? null,
+                        'end_time' => $activity['end_time'] ?? null,
+                        'notes' => $activity['notes'] ?? null,
+                    ])
+                    ->values()
+                    ->all();
+
+                return [
+                    'day_number' => (int) ($day['day_number'] ?? ($index + 1)),
+                    'title' => (string) ($day['title'] ?? 'Day ' . ($index + 1)),
+                    'description' => (string) ($day['description'] ?? ''),
+                    'hotel_id' => in_array((int) ($day['hotel_id'] ?? 0), $allowedHotelIds, true)
+                        ? (int) $day['hotel_id']
+                        : null,
+                    'activities' => $activities,
+                ];
+            })
+            ->values()
+            ->all();
+
+        $plan['trip_name'] = (string) ($plan['trip_name'] ?? 'AI Generated Trip');
+        $plan['trip_description'] = (string) ($plan['trip_description'] ?? '');
+        $plan['markdown_summary'] = (string) ($plan['markdown_summary'] ?? '');
+
+        return $plan;
     }
 }

--- a/resources/views/trips/ai/create.blade.php
+++ b/resources/views/trips/ai/create.blade.php
@@ -2,78 +2,23 @@
     @push('styles')
     <link rel='stylesheet' href="{{asset('css/manual.css')}}">
     <style>
-       
-        .generate-btn {
-            position: relative;
-            padding: 14px 42px;
-            font-size: 17px;
-            font-weight: 600;
-            border-radius: 30px;
-            border: none;
-            cursor: pointer;
-            color: white;
-            background: linear-gradient(135deg, #7f53ac, #647dee);
-            box-shadow: 0 10px 25px rgba(127, 83, 172, 0.35);
-            transition: all 0.3s ease;
-            overflow: hidden;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .generate-btn:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 14px 30px rgba(100, 125, 238, 0.45);
-        }
-
-        .generate-btn:disabled {
-            cursor: not-allowed;
-            opacity: 0.8;
-        }
-
-        
-        .spinner {
-            width: 20px;
-            height: 20px;
-            border: 3px solid rgba(255, 255, 255, 0.3);
-            border-top: 3px solid white;
-            border-radius: 50%;
-            animation: spin 0.8s linear infinite;
-            display: none; 
-            margin-left: 10px;
-        }
-
-        
-        .generate-btn.loading .spinner {
-            display: block;
-        }
-
-        .generate-btn.loading .btn-text {
-            opacity: 0.7;
-        }
-
-        @keyframes spin {
-            0% { transform: rotate(0deg); }
-            100% { transform: rotate(360deg); }
-        }
-
-        .form-container {
-            background: white;
-            padding: 40px;
-            border-radius: 15px;
-            box-shadow: 0 10px 30px rgba(0,0,0,0.1);
-        }
+        .generate-btn { position: relative; padding: 14px 42px; font-size: 17px; font-weight: 600; border-radius: 30px; border: none; cursor: pointer; color: white; background: linear-gradient(135deg, #7f53ac, #647dee); box-shadow: 0 10px 25px rgba(127, 83, 172, 0.35); transition: all 0.3s ease; overflow: hidden; display: inline-flex; align-items: center; justify-content: center; }
+        .generate-btn:hover { transform: translateY(-2px); box-shadow: 0 14px 30px rgba(100, 125, 238, 0.45); }
+        .generate-btn:disabled { cursor: not-allowed; opacity: 0.8; }
+        .spinner { width: 20px; height: 20px; border: 3px solid rgba(255, 255, 255, 0.3); border-top: 3px solid white; border-radius: 50%; animation: spin 0.8s linear infinite; display: none; margin-left: 10px; }
+        .generate-btn.loading .spinner { display: block; }
+        .generate-btn.loading .btn-text { opacity: 0.7; }
+        @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
+        .form-container { background: white; padding: 40px; border-radius: 15px; box-shadow: 0 10px 30px rgba(0,0,0,0.1); }
     </style>
     @endpush
 
     <div class="main-container">
         <header class="mb-8">
-            <a href="{{route('trip.view')}}">
-                <button class="back">Back</button>
-            </a>
+            <a href="{{route('trip.view')}}"><button class="back">Back</button></a>
             <div class="head text-center">
                 <h1 class="text-3xl font-bold">AI Trip Creator</h1>
-                <p class="text-gray-600">Describe your ideal trip and let AI do the planning.</p>
+                <p class="text-gray-600">Groq will use only destinations/hotels/activities that already exist in your database.</p>
             </div>
         </header>
 
@@ -81,7 +26,7 @@
             <form method="POST" action="{{route('ai.generate')}}" id="aiTripForm">
                 @csrf
                 <div class="form-container">
-                    <h2 class="text-xl font-semibold mb-6">✨ Tell us about your dream trip</h2>
+                    <h2 class="text-xl font-semibold mb-6">✨ Build from your DB catalog only</h2>
 
                     @if ($errors->any())
                         <div class="mb-4 px-4 py-3 bg-red-100 text-red-800 rounded">
@@ -95,9 +40,20 @@
 
                     <div class="space-y-6">
                         <div>
+                            <x-input-label for="destination_id">Destination from Database</x-input-label>
+                            <select name="destination_id" id="destination_id" class="w-full rounded-md border-gray-300" required>
+                                <option value="">Select destination</option>
+                                @foreach($destinations as $destination)
+                                    <option value="{{ $destination->id }}" @selected(old('destination_id') == $destination->id)>
+                                        {{ $destination->name }} - {{ $destination->city }}, {{ $destination->country }}
+                                    </option>
+                                @endforeach
+                            </select>
+                        </div>
+
+                        <div>
                             <x-input-label for="description">Trip Description</x-input-label>
-                            <textarea name="description" id="description" 
-                                placeholder="e.g., A romantic 5-day trip to Paris..."
+                            <textarea name="description" id="description" placeholder="e.g., relaxing family style with cultural activities"
                                 class="w-full rounded-md border-gray-300 h-32">{{ old('description') }}</textarea>
                         </div>
 
@@ -111,22 +67,14 @@
                                 <x-text-input type="number" name="duration" id="duration" min="1" value="{{ old('duration', 3) }}" class="w-full"/>
                             </div>
                             <div>
-                                <x-input-label for="start_date">Start Date (Optional)</x-input-label>
-                                <x-text-input type="date" name="start_date" id="start_date" value="{{ old('start_date') }}" class="w-full"/>
-                            </div>
-                            <div>
-                                <x-input-label for="end_date">End Date (Optional)</x-input-label>
-                                <x-text-input type="date" name="end_date" id="end_date" value="{{ old('end_date') }}" class="w-full"/>
-                            </div>
-                            <div>
                                 <x-input-label for="budget">Estimated Budget ($)</x-input-label>
                                 <x-text-input type="number" name="budget" id="budget" placeholder="Optional" value="{{ old('budget') }}" class="w-full"/>
                             </div>
                             <div>
                                 <x-input-label for="language">Language</x-input-label>
                                 <select name="language" id="language" class="w-full rounded-md border-gray-300">
-                                    <option value="en">English</option>
-                                    <option value="ar">Arabic</option>
+                                    <option value="en" @selected(old('language') === 'en')>English</option>
+                                    <option value="ar" @selected(old('language') === 'ar')>Arabic</option>
                                 </select>
                             </div>
                         </div>
@@ -146,14 +94,8 @@
     <script>
         document.getElementById('aiTripForm').addEventListener('submit', function() {
             const btn = document.getElementById('generateBtn');
-            const spinner = document.getElementById('btnSpinner');
-            
-            
             btn.classList.add('loading');
-            
             btn.disabled = true;
-           
-            spinner.style.display = 'block';
         });
     </script>
 </x-app-layout>

--- a/resources/views/trips/ai/show.blade.php
+++ b/resources/views/trips/ai/show.blade.php
@@ -1,52 +1,60 @@
 <x-app-layout>
     @push('styles')
-    <link rel="stylesheet" href="{{asset('css/vehicles.css')}}">
-<link rel="stylesheet" href="{{ asset('css/transport.css') }}">
-<link rel="stylesheet" href="{{ asset('css/aiTrip.css') }}">
+    <link rel="stylesheet" href="{{ asset('css/aiTrip.css') }}">
     @endpush
 
     <div class="trip-container">
-       
         @if (session('success'))
-            <div class="success-message">
-                ✓ {{ session('success') }}
-            </div>
+            <div class="success-message">✓ {{ session('success') }}</div>
         @endif
+
         <div class="trip-header">
             <h1>{{ $trip->name }}</h1>
             <div class="trip-meta">
-                <div class="trip-meta-item">
-                    <strong>📅 Duration:</strong>
-                    <span>{{ $trip->duration ?? \Carbon\Carbon::parse($trip->start_date)->diffInDays(\Carbon\Carbon::parse($trip->end_date)) + 1 }} days</span>
-                </div>
-                <div class="trip-meta-item">
-                    <strong>👥 Travelers:</strong>
-                    <span>{{ $trip->travelers_number }}</span>
-                </div>
-                @if ($trip->budget)
-                    <div class="trip-meta-item">
-                        <strong>💰 Budget:</strong>
-                        <span>${{ number_format($trip->budget, 2) }}</span>
-                    </div>
-                @endif
-                <div class="trip-meta-item">
-                    <strong>📍 Dates:</strong>
-                    <span>{{ \Carbon\Carbon::parse($trip->start_date)->format('M d') }} - {{ \Carbon\Carbon::parse($trip->end_date)->format('M d, Y') }}</span>
-                </div>
+                <div class="trip-meta-item"><strong>📍 Destination:</strong> <span>{{ $trip->destination?->name }}</span></div>
+                <div class="trip-meta-item"><strong>📅 Duration:</strong> <span>{{ $trip->duration_days }} days</span></div>
+                <div class="trip-meta-item"><strong>👥 Max Participants:</strong> <span>{{ $trip->max_participants ?? '-' }}</span></div>
+                <div class="trip-meta-item"><strong>🤖 Source:</strong> <span>AI + DB Catalog</span></div>
             </div>
         </div>
 
-       
         <div class="trip-itinerary">
-            {!! Str::markdown($trip->ai_itinerary) !!}
+            @foreach($trip->days->sortBy('day_number') as $day)
+                <h2>Day {{ $day->day_number }} - {{ $day->title }}</h2>
+                <p>{{ $day->description }}</p>
+
+                @if(!empty($day->highlights))
+                    <ul>
+                        @foreach($day->highlights as $highlight)
+                            <li>{{ $highlight }}</li>
+                        @endforeach
+                    </ul>
+                @endif
+
+                @if($day->hotel)
+                    <p><strong>Hotel:</strong> {{ $day->hotel->name }}</p>
+                @endif
+
+                @if($day->activities->isNotEmpty())
+                    <ul>
+                        @foreach($day->activities as $activity)
+                            <li>
+                                <strong>{{ $activity->activity?->name }}</strong>
+                                @if($activity->start_time || $activity->end_time)
+                                    ({{ $activity->start_time }} - {{ $activity->end_time }})
+                                @endif
+                                @if($activity->notes)
+                                    - {{ $activity->notes }}
+                                @endif
+                            </li>
+                        @endforeach
+                    </ul>
+                @endif
+            @endforeach
         </div>
 
-      
         <div class="trip-actions">
             <a href="{{ route('trips.index') }}" class="btn btn-secondary">← Back to Trips</a>
-            <button class="btn btn-primary" onclick="window.print()">🖨️ Print Itinerary</button>
-           
         </div>
     </div>
-
 </x-app-layout>


### PR DESCRIPTION
### Motivation
- Introduce a safer AI-driven trip generator that uses only existing database records (destinations, hotels, activities) and persists structured trip data into the application's models. 
- Provide language-specific prompt strategies (`en`/`ar`) and a catalog builder so the Groq model cannot invent IDs or unmanaged meeting point data. 
- Replace free-form AI markdown outputs with a validated JSON plan that is sanitized against the catalog and stored as `Trip`, `TripDay`, and `DayActivity` records. 

### Description
- Reworked `AiTripController` to inject `GroqTripPlannerService`, validate `destination_id`, `budget`, and `duration` (`duration` max 30), build trips from the returned plan, persist `Trip`, `TripDay`, and `DayActivity` inside a DB transaction, and provide `nextUniqueSlug` for slugs. 
- Added `TripPromptStrategy` contract and two implementations `EnglishTripPromptStrategy` and `ArabicTripPromptStrategy` to generate system/user messages per language, and added `TripCatalogService` to produce a catalog of `Destination` with recent `hotels` and `activities`. 
- Updated `GroqTripPlannerService` to use the catalog and strategy objects, call Groq with a lower `temperature`, increased `max_tokens`, request structured response, parse JSON output, and run `sanitizeAgainstCatalog` to filter hotels/activities to allowed IDs. 
- Updated views: `resources/views/trips/ai/create.blade.php` to select an existing `Destination` and simplified form/UX, and `resources/views/trips/ai/show.blade.php` to render persisted `days`, `hotel`, and `activities` from the DB instead of raw AI markdown. 
- Schema/field mapping in code now uses fields like `duration_days`, `is_ai_generated`, `ai_prompt`, `max_participants`, `category`, and keeps meeting point fields admin-managed (`meeting_point_description`/`meeting_point_address`). 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc70508368832fb098a7b3c9dfd4c1)