### PR TITLE
Multi-destination AI trips, expanded categories, catalog enrichment and hotel optimization

### DIFF
--- a/app/Enums/Category.php
+++ b/app/Enums/Category.php
@@ -1,10 +1,22 @@
 <?php
+
 namespace App\Enums;
-enum Category: string {
+
+enum Category: string
+{
     case CULTURE = 'culture';
     case NATURE = 'nature';
     case SHOPPING = 'shopping';
     case SPORTS = 'sports';
     case ENTERTAINMENT = 'entertainment';
-}
+    case FAMILY = 'family';
+    case ROMANCE = 'romance';
+    case ADVENTURE = 'adventure';
+    case WELLNESS = 'wellness';
+    case FOOD = 'food';
 
+    public static function values(): array
+    {
+        return array_map(fn (self $category) => $category->value, self::cases());
+    }
+}

--- a/app/Http/Controllers/AiTripController.php
+++ b/app/Http/Controllers/AiTripController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\Category;
 use App\Models\DayActivity;
 use App\Models\Destination;
 use App\Models\Trip;
@@ -20,17 +21,22 @@ class AiTripController extends Controller
     public function create()
     {
         $destinations = Destination::query()->orderBy('name')->get(['id', 'name', 'city', 'country']);
+        $categories = Category::cases();
 
-        return view('trips.ai.create', compact('destinations'));
+        return view('trips.ai.create', compact('destinations', 'categories'));
     }
 
     public function generate(Request $request)
     {
+        $allowedCategories = implode(',', Category::values());
+
         $validated = $request->validate([
-            'destination_id' => 'required|exists:destinations,id',
+            'destination_ids' => 'required|array|min:1',
+            'destination_ids.*' => 'required|integer|exists:destinations,id',
             'description' => 'required|string|max:1000',
-            'category' => 'required|in:culture,nature,shopping,sports,entertainment',
-            'travelers_number' => 'required|integer|min:1',
+            'categories' => 'required|array|min:1',
+            'categories.*' => 'required|string|in:' . $allowedCategories,
+            'max_participants' => 'required|integer|min:1',
             'budget' => 'nullable|numeric|min:0',
             'duration' => 'required|integer|min:1|max:30',
             'start_date' => 'nullable|date',
@@ -38,7 +44,10 @@ class AiTripController extends Controller
             'language' => 'nullable|in:en,ar',
         ]);
 
+        $validated['destination_ids'] = array_values(array_unique($validated['destination_ids']));
+        $validated['categories'] = array_values(array_unique($validated['categories']));
         $language = $validated['language'] ?? 'en';
+
         $plan = $this->groqService->generateTripPlan($validated, $language);
 
         if (! $plan) {
@@ -48,14 +57,15 @@ class AiTripController extends Controller
         $trip = DB::transaction(function () use ($validated, $plan) {
             $name = Str::limit($plan['trip_name'] ?: $validated['description'], 120, '');
             $slugBase = Str::slug($name ?: 'ai-trip');
+            $primaryDestinationId = (int) $validated['destination_ids'][0];
 
             $trip = Trip::create([
-                'destination_id' => $validated['destination_id'],
+                'destination_id' => $primaryDestinationId,
                 'name' => $name,
                 'slug' => $this->nextUniqueSlug($slugBase),
                 'duration_days' => (int) $validated['duration'],
-                'category' => $validated['category'],
-                'max_participants' => (int) $validated['travelers_number'],
+                'category' => implode(',', $validated['categories']),
+                'max_participants' => (int) $validated['max_participants'],
                 // Meeting point is admin-managed (OpenStreetMap + geocoding flow), not AI-managed.
                 'meeting_point_description' => null,
                 'meeting_point_address' => null,
@@ -63,6 +73,12 @@ class AiTripController extends Controller
                 'ai_prompt' => $validated['description'],
                 'status' => 'draft',
             ]);
+
+            $trip->destinations()->sync(
+                collect($validated['destination_ids'])->values()->mapWithKeys(fn (int $destinationId, int $index) => [
+                    $destinationId => ['sort_order' => $index + 1],
+                ])->all()
+            );
 
             foreach ($plan['days'] as $day) {
                 $tripDay = TripDay::create([
@@ -93,7 +109,7 @@ class AiTripController extends Controller
 
     public function show(Trip $trip)
     {
-        $trip->load(['destination', 'days.activities.activity', 'days.hotel']);
+        $trip->load(['destination', 'destinations', 'days.activities.activity', 'days.hotel']);
 
         return view('trips.ai.show', compact('trip'));
     }

--- a/app/Http/Requests/ActivityRequest.php
+++ b/app/Http/Requests/ActivityRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Enums\Category;
 use Illuminate\Foundation\Http\FormRequest;
 
 class ActivityRequest extends FormRequest
@@ -21,7 +22,7 @@ class ActivityRequest extends FormRequest
             'duration' => 'nullable|numeric|min:0',
             'duration_unit' => 'nullable|string|max:50',
             'price' => 'nullable|numeric|min:0',
-            'category' => 'nullable|string|max:100',
+            'category' => ['nullable', 'string', 'in:' . implode(',', Category::values())],
             'is_active' => 'required|boolean',
             'start_time' => 'nullable|date_format:H:i',
             'end_time' => 'nullable|date_format:H:i|after_or_equal:start_time',

--- a/app/Models/Destination.php
+++ b/app/Models/Destination.php
@@ -61,7 +61,15 @@ class Destination extends Model
     }
 
     public function trips()
-    { 
-    return $this->hasMany(Trip::class);
+    {
+        return $this->hasMany(Trip::class);
+    }
+
+    public function catalogTrips()
+    {
+        return $this->belongsToMany(Trip::class, 'trip_destinations')
+            ->withPivot('sort_order')
+            ->orderBy('trip_destinations.sort_order');
     }
 }
+

--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -68,4 +68,12 @@ class Trip extends Model
     return $this->belongsTo(Destination::class);
   }
 
+  public function destinations()
+  {
+    return $this->belongsToMany(Destination::class, 'trip_destinations')
+        ->withPivot('sort_order')
+        ->orderBy('trip_destinations.sort_order');
+  }
+
 }
+

--- a/app/Services/AiTrip/Prompts/ArabicTripPromptStrategy.php
+++ b/app/Services/AiTrip/Prompts/ArabicTripPromptStrategy.php
@@ -19,15 +19,17 @@ class ArabicTripPromptStrategy implements TripPromptStrategy
     public function userMessage(array $tripData, array $catalog): string
     {
         $catalogJson = json_encode($catalog, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE); //convert data to json
+        $selectedCategories = implode('، ', $tripData['categories'] ?? []);
+        $selectedDestinations = implode('، ', array_map('strval', $tripData['destination_ids'] ?? []));
 
         return <<<PROMPT
 أنشئ خطة رحلة لمدة {$tripData['duration']} يوم باللغة العربية بالاعتماد فقط على معرفات البيانات الموجودة في الكتالوج.
 
 مدخلات المستخدم:
-- destination_id: {$tripData['destination_id']}
+- destination_ids (اختيار متعدد): {$selectedDestinations}
 - الوصف: {$tripData['description']}
-- تصنيف الرحلة: {$tripData['category']}
-- عدد المسافرين: {$tripData['travelers_number']}
+- تصنيفات الرحلة (اختيار متعدد): {$selectedCategories}
+- الحد الأقصى للمشاركين: {$tripData['max_participants']}
 - الميزانية: {$tripData['budget']}
 
 قواعد صارمة:
@@ -37,7 +39,12 @@ class ArabicTripPromptStrategy implements TripPromptStrategy
 4) إذا لم تجد خياراً مناسباً لا تخترع بيانات، وتجاوز العنصر.
 5) ركّز على أحدث البيانات (updated_at الأحدث).
 6) عدد الأيام داخل "days" يجب أن يساوي تماماً {$tripData['duration']}.
-7) يجب أن يكون الخرج JSON مطابق تماماً للبنية التالية:
+7) وصف كل يوم لازم يكون غني ومفصل (تنظيم اليوم، نصائح، مبرر ترتيب الأنشطة) وبحد أدنى 35 كلمة.
+8) قواعد توزيع الفنادق:
+   - إذا كانت الرحلة أطول من 5 أيام، بدّل الفندق بين عدة أيام عند توفر خيارات مناسبة.
+   - إذا كانت الأنشطة متباعدة بحسب المنطقة/العنوان، اختر فندق أقرب لذلك اليوم.
+   - إذا كانت الرحلة تشمل أكثر من وجهة مختارة، غيّر الفندق ليتوافق مع تسلسل الوجهات.
+9) يجب أن يكون الخرج JSON مطابق تماماً للبنية التالية:
 {
   "trip_name": "string",
   "trip_description": "string",

--- a/app/Services/AiTrip/Prompts/EnglishTripPromptStrategy.php
+++ b/app/Services/AiTrip/Prompts/EnglishTripPromptStrategy.php
@@ -19,15 +19,17 @@ class EnglishTripPromptStrategy implements TripPromptStrategy
     public function userMessage(array $tripData, array $catalog): string
     {
         $catalogJson = json_encode($catalog, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+        $selectedCategories = implode(', ', $tripData['categories'] ?? []);
+        $selectedDestinations = implode(', ', array_map('strval', $tripData['destination_ids'] ?? []));
 
         return <<<PROMPT
 Create a {$tripData['duration']}-day trip plan in English using only IDs and names that exist in the catalog below.
 
 User input:
-- Destination ID: {$tripData['destination_id']}
+- Destination IDs (multi-select): {$selectedDestinations}
 - Description: {$tripData['description']}
-- Trip category: {$tripData['category']}
-- Travelers: {$tripData['travelers_number']}
+- Trip categories (multi-select): {$selectedCategories}
+- Max participants: {$tripData['max_participants']}
 - Budget: {$tripData['budget']}
 
 STRICT RULES:
@@ -37,7 +39,12 @@ STRICT RULES:
 4) If a requested item does not exist, skip it and keep the plan realistic.
 5) Prefer newest records (higher updated_at values in the catalog).
 6) The number of days in "days" MUST equal exactly {$tripData['duration']}.
-7) Output must be JSON matching this shape exactly:
+7) Day description should be rich and practical (transport rhythm, why this order, meal/family tips) and at least 35 words.
+8) Hotel assignment rules:
+   - If duration > 5 days, vary hotels across days when possible.
+   - If activities look far apart by area/address, choose a closer hotel for that day.
+   - If the itinerary includes multiple selected destinations, switch hotels to match destination flow.
+9) Output must be JSON matching this shape exactly:
 {
   "trip_name": "string",
   "trip_description": "string",

--- a/app/Services/AiTrip/TripCatalogService.php
+++ b/app/Services/AiTrip/TripCatalogService.php
@@ -2,63 +2,89 @@
 
 namespace App\Services\AiTrip;
 
+use App\Enums\Category;
 use App\Models\Destination;
 
 class TripCatalogService
 {
-    public function buildCatalog(int $destinationId, ?string $tripCategory = null): array
+    public function buildCatalog(array $destinationIds, array $tripCategories = []): array
     {
-        $normalizedCategory = $this->normalizeCategory($tripCategory);
+        $destinationIds = collect($destinationIds)->map(fn ($id) => (int) $id)->filter()->unique()->values();
+        $normalizedCategories = $this->normalizeCategories($tripCategories);
 
-        $destination = Destination::query()->with([
-            'hotels' => fn ($query) => $query->orderByDesc('updated_at')->limit(20),
-            'activities' => fn ($query) => $query
-                ->where('is_active', true)
-                ->when($normalizedCategory !== null, fn ($subQuery) => $subQuery->where('category', $normalizedCategory))
-                ->orderBy('price')
-                ->orderBy('duration')
-                ->orderByDesc('updated_at')
-                ->limit(40),
-        ])->findOrFail($destinationId);
+        $destinations = Destination::query()
+            ->whereIn('id', $destinationIds)
+            ->with([
+                'hotels' => fn ($query) => $query->orderByDesc('stars')->orderBy('price_per_night')->orderByDesc('updated_at')->limit(30),
+                'activities' => fn ($query) => $query
+                    ->where('is_active', true)
+                    ->when(! empty($normalizedCategories), fn ($subQuery) => $subQuery->whereIn('category', $normalizedCategories))
+                    ->orderBy('price')
+                    ->orderBy('duration')
+                    ->orderByDesc('updated_at')
+                    ->limit(60),
+            ])
+            ->get();
 
         return [
-            'destination' => [
+            'destinations' => $destinations->map(fn ($destination) => [
                 'id' => $destination->id,
                 'name' => $destination->name,
                 'city' => $destination->city,
                 'country' => $destination->country,
                 'updated_at' => optional($destination->updated_at)?->toDateTimeString(),
-            ],
+            ])->values()->all(),
             'filters' => [
-                'requested_trip_category' => $tripCategory,
-                'normalized_activity_category' => $normalizedCategory,
+                'requested_destination_ids' => $destinationIds->all(),
+                'requested_trip_categories' => $tripCategories,
+                'normalized_activity_categories' => $normalizedCategories,
             ],
-            'hotels' => $destination->hotels->map(fn ($hotel) => [
+            'hotels' => $destinations->flatMap(fn ($destination) => $destination->hotels->map(fn ($hotel) => [
                 'id' => $hotel->id,
+                'destination_id' => $destination->id,
+                'destination_name' => $destination->name,
                 'name' => $hotel->name,
+                'city' => $hotel->city,
+                'country' => $hotel->country,
+                'description' => $hotel->description,
                 'price_per_night' => $hotel->price_per_night,
                 'stars' => $hotel->stars,
+                'amenities' => $hotel->amenities ?? [],
+                'pets_allowed' => $hotel->pets_allowed,
+                'check_in_time' => $hotel->check_in_time?->format('H:i'),
+                'check_out_time' => $hotel->check_out_time?->format('H:i'),
+                'policies' => $hotel->policies,
+                'nearby_landmarks' => $hotel->nearby_landmarks,
                 'updated_at' => optional($hotel->updated_at)?->toDateTimeString(),
-            ])->values()->all(),
-            'activities' => $destination->activities->map(fn ($activity) => [
+            ]))->values()->all(),
+            'activities' => $destinations->flatMap(fn ($destination) => $destination->activities->map(fn ($activity) => [
                 'id' => $activity->id,
+                'destination_id' => $destination->id,
+                'destination_name' => $destination->name,
                 'name' => $activity->name,
+                'description' => $activity->description,
+                'address' => $activity->address,
                 'price' => $activity->price,
                 'category' => $activity->category,
                 'duration' => $activity->duration,
                 'duration_unit' => $activity->duration_unit,
+                'amenities' => $activity->amenities ?? [],
+                'highlights' => $activity->highlights,
                 'updated_at' => optional($activity->updated_at)?->toDateTimeString(),
-            ])->values()->all(),
+            ]))->values()->all(),
         ];
     }
 
-    protected function normalizeCategory(?string $category): ?string
+    protected function normalizeCategories(array $categories): array
     {
-        $normalized = strtolower(trim((string) $category));
-        $normalized = str_replace(' ', '_', $normalized);
+        $allowed = Category::values();
 
-        return in_array($normalized, ['culture', 'nature', 'shopping', 'sports', 'entertainment'], true)
-            ? $normalized
-            : null;
+        return collect($categories)
+            ->map(fn ($category) => strtolower(trim((string) $category)))
+            ->map(fn (string $category) => str_replace(' ', '_', $category))
+            ->filter(fn (string $category) => in_array($category, $allowed, true))
+            ->unique()
+            ->values()
+            ->all();
     }
 }

--- a/app/Services/GroqTripPlannerService.php
+++ b/app/Services/GroqTripPlannerService.php
@@ -41,8 +41,8 @@ class GroqTripPlannerService
 
         $strategy = $this->promptStrategies[$language] ?? $this->promptStrategies['en'];
         $catalog = $this->catalogService->buildCatalog(
-            (int) $tripData['destination_id'],
-            $tripData['category'] ?? null
+            $tripData['destination_ids'] ?? [],
+            $tripData['categories'] ?? []
         );
 
         try {
@@ -135,10 +135,39 @@ class GroqTripPlannerService
             })
             ->all();
 
+        $plan['days'] = $this->optimizeHotelsAcrossDays($plan['days'], $catalog['hotels'] ?? [], $requestedDuration);
+
         $plan['trip_name'] = (string) ($plan['trip_name'] ?? 'AI Generated Trip');
-        $plan['trip_description'] = (string) ($plan['trip_description'] ?? '');
+        $plan['trip_description'] = (string) ($plan['trip_description'] ?? 'A detailed trip crafted with curated local experiences, smart pacing, and practical stay recommendations from your platform catalog.');
         $plan['markdown_summary'] = (string) ($plan['markdown_summary'] ?? '');
 
         return $plan;
+    }
+
+    protected function optimizeHotelsAcrossDays(array $days, array $hotels, int $duration): array
+    {
+        if (empty($days) || empty($hotels)) {
+            return $days;
+        }
+
+        $hotelIds = collect($hotels)->pluck('id')->map(fn ($id) => (int) $id)->values()->all();
+        $activeHotelIndex = 0;
+
+        foreach ($days as $index => $day) {
+            if (! empty($day['hotel_id']) && in_array((int) $day['hotel_id'], $hotelIds, true)) {
+                $currentIndex = array_search((int) $day['hotel_id'], $hotelIds, true);
+                $activeHotelIndex = $currentIndex === false ? $activeHotelIndex : $currentIndex;
+                continue;
+            }
+
+            // For long trips (>5 days), rotate hotel every 3 days for better comfort and location fit.
+            if ($duration > 5 && $index > 0 && $index % 3 === 0) {
+                $activeHotelIndex = ($activeHotelIndex + 1) % count($hotelIds);
+            }
+
+            $days[$index]['hotel_id'] = $hotelIds[$activeHotelIndex];
+        }
+
+        return $days;
     }
 }

--- a/database/factories/ActivityFactory.php
+++ b/database/factories/ActivityFactory.php
@@ -29,6 +29,11 @@ class ActivityFactory extends Factory
             'shopping' => ['Old Souk Shopping', 'Artisan Market Visit', 'Local Boutique Crawl'],
             'sports' => ['Kayaking Session', 'Cycling City Route', 'Rock Climbing Experience'],
             'entertainment' => ['Live Music Night', 'Food Festival Visit', 'City Theater Show'],
+            'family' => ['Family Park Day', 'Interactive Science Center', 'Kid-Friendly Aquarium Visit'],
+            'romance' => ['Sunset Dinner Cruise', 'Couples Spa Session', 'Private Rooftop Dinner'],
+            'adventure' => ['Desert Safari Ride', 'Zipline Challenge', 'Canyon Exploration Tour'],
+            'wellness' => ['Morning Yoga Retreat', 'Thermal Spa Visit', 'Mindfulness Nature Walk'],
+            'food' => ['Street Food Tasting', 'Local Cooking Class', 'Farm-to-Table Experience'],
         ];
 
         return [

--- a/database/migrations/2025_10_01_164135_create_activities_table.php
+++ b/database/migrations/2025_10_01_164135_create_activities_table.php
@@ -29,6 +29,11 @@ return new class extends Migration
                 Category::SHOPPING->value,
                 Category::SPORTS->value,
                 Category::ENTERTAINMENT->value,
+                Category::FAMILY->value,
+                Category::ROMANCE->value,
+                Category::ADVENTURE->value,
+                Category::WELLNESS->value,
+                Category::FOOD->value,
             ]);
             $table->boolean('is_active')->default(true);
             // الوقت والتاريخ

--- a/database/migrations/2026_04_02_100000_expand_activity_category_enum.php
+++ b/database/migrations/2026_04_02_100000_expand_activity_category_enum.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Enums\Category;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        $values = collect(Category::values())
+            ->map(fn (string $value) => "'{$value}'")
+            ->implode(',');
+
+        DB::statement("ALTER TABLE activities MODIFY category ENUM({$values}) NOT NULL");
+    }
+
+    public function down(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        DB::statement("ALTER TABLE activities MODIFY category ENUM('culture','nature','shopping','sports','entertainment') NOT NULL");
+    }
+};

--- a/database/migrations/2026_04_02_120000_create_trip_destinations_table.php
+++ b/database/migrations/2026_04_02_120000_create_trip_destinations_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('trip_destinations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('trip_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('destination_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('sort_order')->default(1);
+            $table->timestamps();
+
+            $table->unique(['trip_id', 'destination_id']);
+        });
+
+        // Backfill existing trips with their primary destination.
+        DB::table('trips')->select(['id', 'destination_id'])->orderBy('id')->chunkById(500, function ($trips) {
+            $now = now();
+            $rows = [];
+
+            foreach ($trips as $trip) {
+                $rows[] = [
+                    'trip_id' => $trip->id,
+                    'destination_id' => $trip->destination_id,
+                    'sort_order' => 1,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ];
+            }
+
+            if (! empty($rows)) {
+                DB::table('trip_destinations')->insert($rows);
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('trip_destinations');
+    }
+};

--- a/database/seeders/ActivitySeeder.php
+++ b/database/seeders/ActivitySeeder.php
@@ -22,6 +22,11 @@ class ActivitySeeder extends Seeder
                 ['name' => 'Kayaking Session', 'category' => 'sports', 'price' => 30, 'duration' => 2],
                 ['name' => 'Evening Cultural Show', 'category' => 'entertainment', 'price' => 40, 'duration' => 2],
                 ['name' => 'Food Festival Experience', 'category' => 'entertainment', 'price' => 18, 'duration' => 2],
+                ['name' => 'Family Theme Park Day', 'category' => 'family', 'price' => 45, 'duration' => 6],
+                ['name' => 'Romantic Sunset Dinner', 'category' => 'romance', 'price' => 80, 'duration' => 3],
+                ['name' => 'Desert Adventure Safari', 'category' => 'adventure', 'price' => 55, 'duration' => 5],
+                ['name' => 'Wellness Spa & Yoga Session', 'category' => 'wellness', 'price' => 65, 'duration' => 4],
+                ['name' => 'Local Culinary Workshop', 'category' => 'food', 'price' => 35, 'duration' => 3],
             ];
 
             foreach ($activities as $activity) {

--- a/resources/views/trips/ai/create.blade.php
+++ b/resources/views/trips/ai/create.blade.php
@@ -8,6 +8,8 @@
         .spinner { width: 20px; height: 20px; border: 3px solid rgba(255, 255, 255, 0.3); border-top: 3px solid white; border-radius: 50%; animation: spin 0.8s linear infinite; display: none; margin-left: 10px; }
         .generate-btn.loading .spinner { display: block; }
         .generate-btn.loading .btn-text { opacity: 0.7; }
+        .category-grid { display: grid; grid-template-columns: repeat(auto-fill,minmax(130px,1fr)); gap: 10px; margin-top: 8px; }
+        .category-box { border: 1px solid #d1d5db; border-radius: 10px; padding: 8px 10px; display: flex; gap: 8px; align-items: center; }
         @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
         .form-container { background: white; padding: 40px; border-radius: 15px; box-shadow: 0 10px 30px rgba(0,0,0,0.1); }
     </style>
@@ -40,15 +42,15 @@
 
                     <div class="space-y-6">
                         <div>
-                            <x-input-label for="destination_id">Destination from Database</x-input-label>
-                            <select name="destination_id" id="destination_id" class="w-full rounded-md border-gray-300" required>
-                                <option value="">Select destination</option>
+                            <x-input-label for="destination_ids">Destinations from Database (Multi-select)</x-input-label>
+                            <select name="destination_ids[]" id="destination_ids" class="w-full rounded-md border-gray-300" multiple required size="6">
                                 @foreach($destinations as $destination)
-                                    <option value="{{ $destination->id }}" @selected(old('destination_id') == $destination->id)>
+                                    <option value="{{ $destination->id }}" @selected(in_array($destination->id, old('destination_ids', [])))>
                                         {{ $destination->name }} - {{ $destination->city }}, {{ $destination->country }}
                                     </option>
                                 @endforeach
                             </select>
+                            <p class="text-sm text-gray-500 mt-2">Use Ctrl/Cmd + click to select multiple destinations.</p>
                         </div>
 
                         <div>
@@ -59,8 +61,8 @@
 
                         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                             <div>
-                                <x-input-label for="travelers_number">Number of Travelers</x-input-label>
-                                <x-text-input type="number" name="travelers_number" id="travelers_number" min="1" value="{{ old('travelers_number', 1) }}" class="w-full"/>
+                                <x-input-label for="max_participants">Max Participants</x-input-label>
+                                <x-text-input type="number" name="max_participants" id="max_participants" min="1" value="{{ old('max_participants', 1) }}" class="w-full"/>
                             </div>
                             <div>
                                 <x-input-label for="duration">Duration (Days)</x-input-label>
@@ -72,17 +74,18 @@
                             </div>
 
                             <div>
-                                <x-input-label for="category">Trip Category</x-input-label>
-                                <select name="category" id="category" class="w-full rounded-md border-gray-300" required>
-                                    <option value="">Select category</option>
-                                    <option value="culture" @selected(old('category') === 'culture')>Culture</option>
-                                    <option value="nature" @selected(old('category') === 'nature')>Nature</option>
-                                    <option value="shopping" @selected(old('category') === 'shopping')>Shopping</option>
-                                    <option value="sports" @selected(old('category') === 'sports')>Sports</option>
-                                    <option value="entertainment" @selected(old('category') === 'entertainment')>Entertainment</option>
-                                </select>
+                                <x-input-label>Trip Categories (Multi-select)</x-input-label>
+                                <div class="category-grid">
+                                    @foreach($categories as $category)
+                                        <label class="category-box">
+                                            <input type="checkbox" name="categories[]" value="{{ $category->value }}"
+                                                {{ in_array($category->value, old('categories', []), true) ? 'checked' : '' }}>
+                                            <span>{{ ucfirst($category->value) }}</span>
+                                        </label>
+                                    @endforeach
+                                </div>
                             </div>
-                            
+
                             <div>
                                 <x-input-label for="language">Language</x-input-label>
                                 <select name="language" id="language" class="w-full rounded-md border-gray-300">

--- a/resources/views/trips/ai/show.blade.php
+++ b/resources/views/trips/ai/show.blade.php
@@ -11,7 +11,7 @@
         <div class="trip-header">
             <h1>{{ $trip->name }}</h1>
             <div class="trip-meta">
-                <div class="trip-meta-item"><strong>📍 Destination:</strong> <span>{{ $trip->destination?->name }}</span></div>
+                <div class="trip-meta-item"><strong>📍 Destinations:</strong> <span>{{ $trip->destinations->pluck('name')->join(' • ') ?: $trip->destination?->name }}</span></div>
                 <div class="trip-meta-item"><strong>📅 Duration:</strong> <span>{{ $trip->duration_days }} days</span></div>
                 <div class="trip-meta-item"><strong>👥 Max Participants:</strong> <span>{{ $trip->max_participants ?? '-' }}</span></div>
                 <div class="trip-meta-item"><strong>🤖 Source:</strong> <span>AI + DB Catalog</span></div>
@@ -20,7 +20,11 @@
 
         <div class="trip-itinerary">
             @foreach($trip->days->sortBy('day_number') as $day)
-                <h2>Day {{ $day->day_number }} - {{ $day->title }}</h2>
+                @php
+                    $cleanTitle = trim((string) $day->title);
+                    $cleanTitle = preg_replace('/^day\s*\d+\s*[-:]?\s*/i', '', $cleanTitle);
+                @endphp
+                <h2>Day {{ $day->day_number }}@if(!empty($cleanTitle)) - {{ $cleanTitle }}@endif</h2>
                 <p>{{ $day->description }}</p>
 
                 @if(!empty($day->highlights))
@@ -32,7 +36,23 @@
                 @endif
 
                 @if($day->hotel)
-                    <p><strong>Hotel:</strong> {{ $day->hotel->name }} - {{$day->hotel->stars}} Stars / price per night:  {{ $day->hotel->price_per_night }}$ </p> <br>
+                    <p><strong>Hotel:</strong> {{ $day->hotel->name }} — {{ $day->hotel->stars }} Stars / ${{ $day->hotel->price_per_night }} per night</p>
+                    @if(!empty($day->hotel->description))
+                        <p><strong>About hotel:</strong> {{ $day->hotel->description }}</p>
+                    @endif
+                    @if(!empty($day->hotel->amenities))
+                        <p><strong>Amenities:</strong> {{ implode(', ', $day->hotel->amenities) }}</p>
+                    @endif
+                    @if($day->hotel->check_in_time || $day->hotel->check_out_time)
+                        <p><strong>Check in/out:</strong> {{ $day->hotel->check_in_time?->format('H:i') ?? '-' }} / {{ $day->hotel->check_out_time?->format('H:i') ?? '-' }}</p>
+                    @endif
+                    @if(!empty($day->hotel->nearby_landmarks))
+                        <p><strong>Nearby landmarks:</strong> {{ $day->hotel->nearby_landmarks }}</p>
+                    @endif
+                    @if(!empty($day->hotel->policies))
+                        <p><strong>Policies:</strong> {{ $day->hotel->policies }}</p>
+                    @endif
+                    <br>
                 @endif
 
                 @if($day->activities->isNotEmpty())
@@ -40,10 +60,8 @@
                         @foreach($day->activities as $activity)
                             <li>
                                 <strong>{{ $activity->activity?->name }}</strong> - {{ $activity->activity?->price }}$ <br>
-                                
                                 @if($activity->notes)
-                                <strong>Notes:</strong>
-                                    - {{ $activity->notes }}
+                                    <strong>Notes:</strong> {{ $activity->notes }}
                                 @endif
                             </li>
                         @endforeach


### PR DESCRIPTION
### Motivation
- Allow AI trip generation to support multiple selected destinations and multiple activity categories instead of single values. 
- Extend activity/category taxonomy to include family/romance/adventure/wellness/food and make catalog-driven prompts and validation reflect that. 
- Improve the trip catalog shape (richer hotels/activities metadata) and assign destinations to trips via a pivot for ordered multi-destination itineraries. 
- Improve hotel assignment across days (rotate/optimize) and strengthen AI prompt rules to produce richer day descriptions and enforce catalog usage. 

### Description
- Expanded `App\nEnums\nCategory` with five new categories and added `values()` helper for validations. 
- Reworked AI flow to accept arrays: `AiTripController` now accepts `destination_ids[]` and `categories[]`, validates and deduplicates them, saves `category` as comma-separated categories, syncs `trip_destinations` pivot with `sort_order`, and loads `destinations` when showing trips. 
- Refactored `TripCatalogService` to build a catalog from many destinations and categories, returning enriched `hotels` and `activities` arrays and normalized categories via the enum. 
- Updated prompt strategies (`EnglishTripPromptStrategy` and `ArabicTripPromptStrategy`) to include multi-select inputs and stronger/hotel/day rules. 
- `GroqTripPlannerService` now calls the catalog with arrays, sets a more descriptive default `trip_description`, and adds `optimizeHotelsAcrossDays()` to assign/rotate hotels across days. 
- Added DB changes: migration to create `trip_destinations` pivot table with backfill, migration to expand `activities.category` enum to include new values, and a seeder/factory updates to use new categories. 
- Model updates: `Trip::destinations()` and `Destination::catalogTrips()` relations added, minor cleanup in `Destination` methods. 
- Views updated: AI create form supports multi-select destinations and multi-category checkboxes; show view displays multiple destinations and more hotel/activity details. 

### Testing
- Ran the application test suite with `php artisan test` and the tests passed. 
- Applied migrations locally with `php artisan migrate` (including pivot backfill) and verified no migration errors. 
- Manual smoke checks of the AI create and show flows were exercised in development to confirm multi-select inputs and saved pivot data.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea1a99e58832fb515cd3e6164006f)