### PR TITLE
Improve AI trip show layout with sectioned day cards

### DIFF
--- a/public/css/aiTrip.css
+++ b/public/css/aiTrip.css
@@ -1,202 +1,205 @@
+.trip-container {
+    max-width: 1300px;
+    margin: 0 auto;
+    padding: 30px 20px;
+    background: white;
+    border-radius: 14px;
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+}
 
-        .trip-container {
-            max-width: 1400px;
-            margin: 0 auto;
-            padding: 30px 20px;
-            background: white;
-            border-radius: 10px;
-            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-            
-        }
+.trip-header {
+    border-bottom: 3px solid #7f53ac;
+    padding-bottom: 20px;
+    margin: 30px 0;
+}
 
-        .trip-header {
-            border-bottom: 3px solid #7f53ac;
-            padding-bottom: 20px;
-            margin-bottom: 30px;
-            margin-top:30px;
-        }
+.trip-header h1 {
+    color: #1f2937;
+    font-size: 30px;
+    margin: 0 0 10px 0;
+}
 
-        .trip-header h1 {
-            color: #333;
-            font-size: 28px;
-            margin: 0 0 10px 0;
-        }
+.trip-meta {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+    color: #4b5563;
+    font-size: 14px;
+}
 
-        .trip-meta {
-            display: flex;
-            gap: 30px;
-            flex-wrap: wrap;
-            color: #666;
-            font-size: 14px;
-        }
+.trip-meta-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 999px;
+    padding: 6px 12px;
+}
 
-        .trip-meta-item {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-        }
+.trip-meta-item strong {
+    color: #111827;
+}
 
-        .trip-meta-item strong {
-            color: #333;
-        }
+.trip-itinerary {
+    line-height: 1.7;
+    color: #1f2937;
+    display: grid;
+    gap: 22px;
+}
 
-        /* تنسيق محتوى Markdown */
-        .trip-itinerary {
-            line-height: 1.8;
-            color: #333;
-        }
+.day-card {
+    border: 1px solid #e5e7eb;
+    border-left: 5px solid #7f53ac;
+    border-radius: 14px;
+    background: linear-gradient(180deg, #ffffff 0%, #fbfcff 100%);
+    padding: 20px;
+    box-shadow: 0 6px 16px rgba(100, 125, 238, 0.08);
+}
 
-        .trip-itinerary h1 {
-            color: #7f53ac;
-            font-size: 24px;
-            margin-top: 30px;
-            margin-bottom: 15px;
-            border-bottom: 2px solid #e0e0e0;
-            padding-bottom: 10px;
-        }
+.day-card-header h2 {
+    margin: 0;
+    color: #4338ca;
+    font-size: 22px;
+}
 
-        .trip-itinerary h2 {
-            color: #647dee;
-            font-size: 20px;
-            margin-top: 25px;
-            margin-bottom: 12px;
-        }
+.day-description {
+    margin: 10px 0 0;
+    color: #374151;
+}
 
-        .trip-itinerary h3 {
-            color: #8b7bb8;
-            font-size: 16px;
-            margin-top: 18px;
-            margin-bottom: 10px;
-        }
+.info-section {
+    margin-top: 16px;
+    border-radius: 12px;
+    padding: 14px 16px;
+    border: 1px solid #e5e7eb;
+    background-color: #ffffff;
+}
 
-        .trip-itinerary ul,
-        .trip-itinerary ol {
-            margin: 15px 0;
-            padding-left: 30px;
-        }
+.info-section h3 {
+    margin: 0 0 10px;
+    font-size: 16px;
+    color: #111827;
+}
 
-        .trip-itinerary li {
-            margin: 8px 0;
-        }
+.highlights-section {
+    background: #f5f3ff;
+    border-color: #ddd6fe;
+}
 
-        .trip-itinerary a {
-            color: #647dee;
-            text-decoration: none;
-            border-bottom: 1px dotted #647dee;
-        }
+.hotel-section {
+    background: #eff6ff;
+    border-color: #bfdbfe;
+}
 
-        .trip-itinerary a:hover {
-            color: #7f53ac;
-            border-bottom-color: #7f53ac;
-        }
+.activities-section {
+    background: #f0fdf4;
+    border-color: #bbf7d0;
+}
 
-        .trip-itinerary code {
-            background-color: #f5f5f5;
-            padding: 2px 6px;
-            border-radius: 3px;
-            font-family: 'Courier New', monospace;
-            color: #d63384;
-        }
+.tag-list {
+    margin: 0;
+    padding-left: 20px;
+}
 
-        .trip-itinerary blockquote {
-            border-left: 4px solid #7f53ac;
-            padding-left: 15px;
-            margin: 15px 0;
-            color: #666;
-            font-style: italic;
-        }
+.detail-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 8px 16px;
+    margin-bottom: 10px;
+}
 
-        .trip-itinerary table {
-            width: 100%;
-            border-collapse: collapse;
-            margin: 20px 0;
-        }
+.detail-item {
+    color: #374151;
+}
 
-        .trip-itinerary table th,
-        .trip-itinerary table td {
-            border: 1px solid #ddd;
-            padding: 12px;
-            text-align: left;
-        }
+.activity-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 12px;
+}
 
-        .trip-itinerary table th {
-            background-color: #f5f5f5;
-            font-weight: bold;
-            color: #333;
-        }
+.activity-card {
+    background: #ffffff;
+    border: 1px solid #dcfce7;
+    border-radius: 10px;
+    padding: 12px;
+}
 
-        .trip-itinerary table tr:nth-child(even) {
-            background-color: #fafafa;
-        }
+.activity-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+}
 
-        .trip-actions {
-            margin-top: 40px;
-            padding-top: 20px;
-            border-top: 1px solid #e0e0e0;
-            display: flex;
-            gap: 15px;
-            flex-wrap: wrap;
-        }
+.price-pill {
+    background: #22c55e;
+    color: #ffffff;
+    font-size: 13px;
+    font-weight: 700;
+    border-radius: 999px;
+    padding: 4px 10px;
+}
 
-        .btn {
-            padding: 12px 24px;
-            border: none;
-            border-radius: 5px;
-            font-size: 14px;
-            font-weight: 600;
-            cursor: pointer;
-            text-decoration: none;
-            display: inline-block;
-            transition: all 0.3s ease;
-        }
+.trip-actions {
+    margin-top: 32px;
+    padding-top: 20px;
+    border-top: 1px solid #e5e7eb;
+    display: flex;
+    gap: 15px;
+    flex-wrap: wrap;
+}
 
-        .btn-primary {
-            background: linear-gradient(135deg, #7f53ac, #647dee);
-            color: white;
-        }
+.btn {
+    padding: 12px 24px;
+    border: none;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    text-decoration: none;
+    display: inline-block;
+    transition: all 0.25s ease;
+}
 
-        .btn-primary:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 6px 12px rgba(127, 83, 172, 0.3);
-        }
+.btn-secondary {
+    background: #e5e7eb;
+    color: #111827;
+}
 
-        .btn-secondary {
-            background: #e0e0e0;
-            color: #333;
-        }
+.btn-secondary:hover {
+    background: #d1d5db;
+}
 
-        .btn-secondary:hover {
-            background: #d0d0d0;
-        }
+.success-message {
+    background-color: #dcfce7;
+    color: #166534;
+    padding: 15px;
+    border-radius: 8px;
+    margin-bottom: 20px;
+    border: 1px solid #86efac;
+}
 
-        .success-message {
-            background-color: #d4edda;
-            color: #155724;
-            padding: 15px;
-            border-radius: 5px;
-            margin-bottom: 20px;
-            border: 1px solid #c3e6cb;
-        }
+@media (max-width: 768px) {
+    .trip-container {
+        padding: 20px 14px;
+    }
 
-        @media (max-width: 768px) {
-            .trip-container {
-                padding: 20px 15px;
-            }
+    .trip-header h1 {
+        font-size: 24px;
+    }
 
-            .trip-header h1 {
-                font-size: 22px;
-            }
+    .trip-meta {
+        flex-direction: column;
+        gap: 8px;
+    }
 
-            .trip-meta {
-                flex-direction: column;
-                gap: 10px;
-            }
+    .day-card {
+        padding: 16px;
+    }
 
-            .trip-itinerary h1 {
-                font-size: 20px;
-            }
-
-            .trip-itinerary h2 {
-                font-size: 18px;
-            }
-        }
+    .day-card-header h2 {
+        font-size: 20px;
+    }
+}

--- a/resources/views/trips/ai/show.blade.php
+++ b/resources/views/trips/ai/show.blade.php
@@ -24,49 +24,71 @@
                     $cleanTitle = trim((string) $day->title);
                     $cleanTitle = preg_replace('/^day\s*\d+\s*[-:]?\s*/i', '', $cleanTitle);
                 @endphp
-                <h2>Day {{ $day->day_number }}@if(!empty($cleanTitle)) - {{ $cleanTitle }}@endif</h2>
-                <p>{{ $day->description }}</p>
 
-                @if(!empty($day->highlights))
-                    <ul>
-                        @foreach($day->highlights as $highlight)
-                            <li>{{ $highlight }}</li>
-                        @endforeach
-                    </ul>
-                @endif
+                <article class="day-card">
+                    <header class="day-card-header">
+                        <h2>Day {{ $day->day_number }}@if(!empty($cleanTitle)) - {{ $cleanTitle }}@endif</h2>
+                    </header>
 
-                @if($day->hotel)
-                    <p><strong>Hotel:</strong> {{ $day->hotel->name }} — {{ $day->hotel->stars }} Stars / ${{ $day->hotel->price_per_night }} per night</p>
-                    @if(!empty($day->hotel->description))
-                        <p><strong>About hotel:</strong> {{ $day->hotel->description }}</p>
+                    @if(!empty($day->description))
+                        <p class="day-description">{{ $day->description }}</p>
                     @endif
-                    @if(!empty($day->hotel->amenities))
-                        <p><strong>Amenities:</strong> {{ implode(', ', $day->hotel->amenities) }}</p>
-                    @endif
-                    @if($day->hotel->check_in_time || $day->hotel->check_out_time)
-                        <p><strong>Check in/out:</strong> {{ $day->hotel->check_in_time?->format('H:i') ?? '-' }} / {{ $day->hotel->check_out_time?->format('H:i') ?? '-' }}</p>
-                    @endif
-                    @if(!empty($day->hotel->nearby_landmarks))
-                        <p><strong>Nearby landmarks:</strong> {{ $day->hotel->nearby_landmarks }}</p>
-                    @endif
-                    @if(!empty($day->hotel->policies))
-                        <p><strong>Policies:</strong> {{ $day->hotel->policies }}</p>
-                    @endif
-                    <br>
-                @endif
 
-                @if($day->activities->isNotEmpty())
-                    <ul>
-                        @foreach($day->activities as $activity)
-                            <li>
-                                <strong>{{ $activity->activity?->name }}</strong> - {{ $activity->activity?->price }}$ <br>
-                                @if($activity->notes)
-                                    <strong>Notes:</strong> {{ $activity->notes }}
-                                @endif
-                            </li>
-                        @endforeach
-                    </ul>
-                @endif
+                    @if(!empty($day->highlights))
+                        <section class="info-section highlights-section">
+                            <h3>✨ Highlights</h3>
+                            <ul class="tag-list">
+                                @foreach($day->highlights as $highlight)
+                                    <li>{{ $highlight }}</li>
+                                @endforeach
+                            </ul>
+                        </section>
+                    @endif
+
+                    @if($day->hotel)
+                        <section class="info-section hotel-section">
+                            <h3>🏨 Hotel Details</h3>
+                            <div class="detail-grid">
+                                <div class="detail-item"><strong>Name:</strong> <span>{{ $day->hotel->name }}</span></div>
+                                <div class="detail-item"><strong>Stars:</strong> <span>{{ $day->hotel->stars }} ★</span></div>
+                                <div class="detail-item"><strong>Price / Night:</strong> <span>${{ $day->hotel->price_per_night }}</span></div>
+                                <div class="detail-item"><strong>Check in / out:</strong> <span>{{ $day->hotel->check_in_time?->format('H:i') ?? '-' }} / {{ $day->hotel->check_out_time?->format('H:i') ?? '-' }}</span></div>
+                            </div>
+
+                            @if(!empty($day->hotel->description))
+                                <p><strong>About hotel:</strong> {{ $day->hotel->description }}</p>
+                            @endif
+                            @if(!empty($day->hotel->amenities))
+                                <p><strong>Amenities:</strong> {{ implode(', ', $day->hotel->amenities) }}</p>
+                            @endif
+                            @if(!empty($day->hotel->nearby_landmarks))
+                                <p><strong>Nearby landmarks:</strong> {{ $day->hotel->nearby_landmarks }}</p>
+                            @endif
+                            @if(!empty($day->hotel->policies))
+                                <p><strong>Policies:</strong> {{ $day->hotel->policies }}</p>
+                            @endif
+                        </section>
+                    @endif
+
+                    @if($day->activities->isNotEmpty())
+                        <section class="info-section activities-section">
+                            <h3>🎯 Activities</h3>
+                            <div class="activity-list">
+                                @foreach($day->activities as $activity)
+                                    <div class="activity-card">
+                                        <div class="activity-row">
+                                            <strong>{{ $activity->activity?->name }}</strong>
+                                            <span class="price-pill">${{ $activity->activity?->price }}</span>
+                                        </div>
+                                        @if($activity->notes)
+                                            <p><strong>Notes:</strong> {{ $activity->notes }}</p>
+                                        @endif
+                                    </div>
+                                @endforeach
+                            </div>
+                        </section>
+                    @endif
+                </article>
             @endforeach
         </div>
 


### PR DESCRIPTION
### Motivation
- The AI trip "show" page was rendering all content in a single continuous block making it hard to distinguish activities, hotel info and day-level summaries. 
- Improve readability and visual hierarchy so users can quickly scan each day and identify hotels, highlights and activities.

### Description
- Restructured the view `resources/views/trips/ai/show.blade.php` to render each day as an individual `article.day-card` and split content into `Highlights`, `Hotel Details`, and `Activities` sections.  
- Added semantic classes (`day-card`, `info-section`, `highlights-section`, `hotel-section`, `activities-section`, `activity-card`, `price-pill`, etc.) and moved description/highlights/hotel/activities into those blocks.  
- Rewrote `public/css/aiTrip.css` to implement the new card layout, metadata pills, section backgrounds, activity cards with a price pill, improved spacing, shadows and rounded corners, and responsive tweaks for mobile.  
- Kept existing data bindings and conditional checks; changes are presentational only and should not affect backend logic.

### Testing
- Attempted to run `php artisan test --filter=ExampleTest`, but the run failed because `vendor/autoload.php` is missing in the environment (dependencies not installed).  
- No other automated tests were executed in this environment; manual inspection of the generated Blade and CSS files was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceac71abe8832facb567a17ade1890)