### PR TITLE
Extract TripPlanSanitizer from GroqTripPlannerService

### DIFF
--- a/app/Services/AiTrip/Sanitizers/TripPlanSanitizer.php
+++ b/app/Services/AiTrip/Sanitizers/TripPlanSanitizer.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Services\AiTrip\Sanitizers;
+
+class TripPlanSanitizer
+{
+    public function sanitizeAgainstCatalog(array $plan, array $catalog, int $requestedDuration): array
+    {
+        $allowedHotelIds = collect($catalog['hotels'])->pluck('id')->map(fn ($id) => (int) $id)->all();
+        $allowedActivityIds = collect($catalog['activities'])->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        $sanitizedDays = collect($plan['days'] ?? [])
+            ->map(function ($day, $index) use ($allowedHotelIds, $allowedActivityIds) {
+                $activities = collect($day['activities'] ?? [])
+                    ->filter(fn ($activity) => in_array((int) ($activity['activity_id'] ?? 0), $allowedActivityIds, true))
+                    ->map(fn ($activity) => [
+                        'activity_id' => (int) $activity['activity_id'],
+                        'start_time' => $activity['start_time'] ?? null,
+                        'end_time' => $activity['end_time'] ?? null,
+                        'notes' => $activity['notes'] ?? null,
+                    ])
+                    ->values()
+                    ->all();
+
+                return [
+                    'day_number' => (int) ($day['day_number'] ?? ($index + 1)),
+                    'title' => (string) ($day['title'] ?? 'Day ' . ($index + 1)),
+                    'description' => (string) ($day['description'] ?? ''),
+                    'hotel_id' => in_array((int) ($day['hotel_id'] ?? 0), $allowedHotelIds, true)
+                        ? (int) $day['hotel_id']
+                        : null,
+                    'activities' => $activities,
+                ];
+            })
+            ->values()
+            ->all();
+
+        $requestedDuration = max(1, $requestedDuration);
+        $plan['days'] = collect(range(1, $requestedDuration))
+            ->map(function (int $dayNumber) use ($sanitizedDays) {
+                $existing = $sanitizedDays[$dayNumber - 1] ?? null;
+
+                if ($existing) {
+                    $existing['day_number'] = $dayNumber;
+                    return $existing;
+                }
+
+                return [
+                    'day_number' => $dayNumber,
+                    'title' => 'Day ' . $dayNumber,
+                    'description' => '',
+                    'hotel_id' => null,
+                    'activities' => [],
+                ];
+            })
+            ->all();
+
+        $plan['days'] = $this->optimizeHotelsAcrossDays($plan['days'], $catalog['hotels'] ?? [], $requestedDuration);
+
+        $plan['trip_name'] = (string) ($plan['trip_name'] ?? 'AI Generated Trip');
+        $plan['trip_description'] = (string) ($plan['trip_description'] ?? 'A detailed trip crafted with curated local experiences, smart pacing, and practical stay recommendations from your platform catalog.');
+        $plan['markdown_summary'] = (string) ($plan['markdown_summary'] ?? '');
+
+        return $plan;
+    }
+
+    protected function optimizeHotelsAcrossDays(array $days, array $hotels, int $duration): array
+    {
+        if (empty($days) || empty($hotels)) {
+            return $days;
+        }
+
+        $hotelIds = collect($hotels)->pluck('id')->map(fn ($id) => (int) $id)->values()->all();
+        $activeHotelIndex = 0;
+
+        foreach ($days as $index => $day) {
+            if (! empty($day['hotel_id']) && in_array((int) $day['hotel_id'], $hotelIds, true)) {
+                $currentIndex = array_search((int) $day['hotel_id'], $hotelIds, true);
+                $activeHotelIndex = $currentIndex === false ? $activeHotelIndex : $currentIndex;
+                continue;
+            }
+
+            // For long trips (>5 days), rotate hotel every 3 days for better comfort and location fit.
+            if ($duration > 5 && $index > 0 && $index % 3 === 0) {
+                $activeHotelIndex = ($activeHotelIndex + 1) % count($hotelIds);
+            }
+
+            $days[$index]['hotel_id'] = $hotelIds[$activeHotelIndex];
+        }
+
+        return $days;
+    }
+}

--- a/app/Services/GroqTripPlannerService.php
+++ b/app/Services/GroqTripPlannerService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Services\AiTrip\Contracts\TripPromptStrategy;
 use App\Services\AiTrip\Prompts\ArabicTripPromptStrategy;
 use App\Services\AiTrip\Prompts\EnglishTripPromptStrategy;
+use App\Services\AiTrip\Sanitizers\TripPlanSanitizer;
 use App\Services\AiTrip\TripCatalogService;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -18,8 +19,10 @@ class GroqTripPlannerService
     /** @var array<string, TripPromptStrategy> */
     protected array $promptStrategies;
 
-    public function __construct(protected TripCatalogService $catalogService)
-    {
+    public function __construct(
+        protected TripCatalogService $catalogService,
+        protected TripPlanSanitizer $tripPlanSanitizer
+    ) {
         $this->apiKey = (string) env('GROQ_API_KEY', '');
 
         $strategies = [
@@ -77,97 +80,10 @@ class GroqTripPlannerService
                 return null;
             }
 
-            return $this->sanitizeAgainstCatalog($decoded, $catalog, (int) ($tripData['duration'] ?? 1));
+            return $this->tripPlanSanitizer->sanitizeAgainstCatalog($decoded, $catalog, (int) ($tripData['duration'] ?? 1));
         } catch (\Throwable $e) {
             Log::error('Groq API Exception', ['message' => $e->getMessage()]);
             return null;
         }
-    }
-
-    protected function sanitizeAgainstCatalog(array $plan, array $catalog, int $requestedDuration): array
-    {
-        $allowedHotelIds = collect($catalog['hotels'])->pluck('id')->map(fn ($id) => (int) $id)->all();
-        $allowedActivityIds = collect($catalog['activities'])->pluck('id')->map(fn ($id) => (int) $id)->all();
-
-        $sanitizedDays = collect($plan['days'] ?? [])
-            ->map(function ($day, $index) use ($allowedHotelIds, $allowedActivityIds) {
-                $activities = collect($day['activities'] ?? [])
-                    ->filter(fn ($activity) => in_array((int) ($activity['activity_id'] ?? 0), $allowedActivityIds, true))
-                    ->map(fn ($activity) => [
-                        'activity_id' => (int) $activity['activity_id'],
-                        'start_time' => $activity['start_time'] ?? null,
-                        'end_time' => $activity['end_time'] ?? null,
-                        'notes' => $activity['notes'] ?? null,
-                    ])
-                    ->values()
-                    ->all();
-
-                return [
-                    'day_number' => (int) ($day['day_number'] ?? ($index + 1)),
-                    'title' => (string) ($day['title'] ?? 'Day ' . ($index + 1)),
-                    'description' => (string) ($day['description'] ?? ''),
-                    'hotel_id' => in_array((int) ($day['hotel_id'] ?? 0), $allowedHotelIds, true)
-                        ? (int) $day['hotel_id']
-                        : null,
-                    'activities' => $activities,
-                ];
-            })
-            ->values()
-            ->all();
-
-        $requestedDuration = max(1, $requestedDuration);
-        $plan['days'] = collect(range(1, $requestedDuration))
-            ->map(function (int $dayNumber) use ($sanitizedDays) {
-                $existing = $sanitizedDays[$dayNumber - 1] ?? null;
-
-                if ($existing) {
-                    $existing['day_number'] = $dayNumber;
-                    return $existing;
-                }
-
-                return [
-                    'day_number' => $dayNumber,
-                    'title' => 'Day ' . $dayNumber,
-                    'description' => '',
-                    'hotel_id' => null,
-                    'activities' => [],
-                ];
-            })
-            ->all();
-
-        $plan['days'] = $this->optimizeHotelsAcrossDays($plan['days'], $catalog['hotels'] ?? [], $requestedDuration);
-
-        $plan['trip_name'] = (string) ($plan['trip_name'] ?? 'AI Generated Trip');
-        $plan['trip_description'] = (string) ($plan['trip_description'] ?? 'A detailed trip crafted with curated local experiences, smart pacing, and practical stay recommendations from your platform catalog.');
-        $plan['markdown_summary'] = (string) ($plan['markdown_summary'] ?? '');
-
-        return $plan;
-    }
-
-    protected function optimizeHotelsAcrossDays(array $days, array $hotels, int $duration): array
-    {
-        if (empty($days) || empty($hotels)) {
-            return $days;
-        }
-
-        $hotelIds = collect($hotels)->pluck('id')->map(fn ($id) => (int) $id)->values()->all();
-        $activeHotelIndex = 0;
-
-        foreach ($days as $index => $day) {
-            if (! empty($day['hotel_id']) && in_array((int) $day['hotel_id'], $hotelIds, true)) {
-                $currentIndex = array_search((int) $day['hotel_id'], $hotelIds, true);
-                $activeHotelIndex = $currentIndex === false ? $activeHotelIndex : $currentIndex;
-                continue;
-            }
-
-            // For long trips (>5 days), rotate hotel every 3 days for better comfort and location fit.
-            if ($duration > 5 && $index > 0 && $index % 3 === 0) {
-                $activeHotelIndex = ($activeHotelIndex + 1) % count($hotelIds);
-            }
-
-            $days[$index]['hotel_id'] = $hotelIds[$activeHotelIndex];
-        }
-
-        return $days;
     }
 }


### PR DESCRIPTION
### Motivation
- Improve separation of concerns by moving all AI-generated trip plan sanitization and validation out of `GroqTripPlannerService` so the service only handles catalog building and AI request/response orchestration.
- Make sanitization reusable and independently testable by placing it in a dedicated class.

### Description
- Added a new class `App\Services\AiTrip\Sanitizers\TripPlanSanitizer` that contains the moved methods `sanitizeAgainstCatalog` and `optimizeHotelsAcrossDays` with the original logic preserved.
- Updated `GroqTripPlannerService` to accept a `TripPlanSanitizer` via constructor dependency injection and delegate the final sanitization call to `tripPlanSanitizer->sanitizeAgainstCatalog(...)`.
- Kept the returned plan structure, default population, activity/hotel filtering, and hotel-rotation logic unchanged to preserve external behavior.
- Avoided new interfaces or extra abstractions to keep the change minimal and focused.

### Testing
- Ran `php -l app/Services/AiTrip/Sanitizers/TripPlanSanitizer.php` which reported no syntax errors.
- Ran `php -l app/Services/GroqTripPlannerService.php` which reported no syntax errors.
- Attempted `php artisan test --filter=ExampleTest` but tests could not run in this environment because `vendor/autoload.php` is missing, so automated test execution was not possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ced3a32854832f84b326fc05b94290)