### PR TITLE
Add AI trip completion flow (tabbed forms) and improve trip search/status

### DIFF
--- a/app/Http/Controllers/AiTripController.php
+++ b/app/Http/Controllers/AiTripController.php
@@ -3,10 +3,19 @@
 namespace App\Http\Controllers;
 
 use App\Enums\Category;
+use App\Models\Activity;
 use App\Models\DayActivity;
 use App\Models\Destination;
+use App\Models\Hotel;
 use App\Models\Trip;
 use App\Models\TripDay;
+use App\Models\TripExclude;
+use App\Models\TripHighlight;
+use App\Models\TripImage;
+use App\Models\TripInclude;
+use App\Models\TripPackage;
+use App\Models\TripPackageHotel;
+use App\Models\TripSchedule;
 use App\Services\GroqTripPlannerService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -39,8 +48,6 @@ class AiTripController extends Controller
             'max_participants' => 'required|integer|min:1',
             'budget' => 'nullable|numeric|min:0',
             'duration' => 'required|integer|min:1|max:30',
-           // 'start_date' => 'nullable|date',
-            //'end_date' => 'nullable|date|after_or_equal:start_date',
             'language' => 'nullable|in:en,ar',
         ]);
 
@@ -63,10 +70,10 @@ class AiTripController extends Controller
                 'destination_id' => $primaryDestinationId,
                 'name' => $name,
                 'slug' => $this->nextUniqueSlug($slugBase),
+                'description' => $plan['trip_description'] ?? null,
                 'duration_days' => (int) $validated['duration'],
                 'category' => implode(',', $validated['categories']),
                 'max_participants' => (int) $validated['max_participants'],
-                // Meeting point is admin-managed (OpenStreetMap + geocoding flow), not AI-managed.
                 'meeting_point_description' => null,
                 'meeting_point_address' => null,
                 'is_ai_generated' => true,
@@ -86,7 +93,7 @@ class AiTripController extends Controller
                     'day_number' => (int) $day['day_number'],
                     'title' => $day['title'],
                     'description' => $day['description'],
-                    'highlights' => [], //admin-managed
+                    'highlights' => [],
                     'hotel_id' => $day['hotel_id'] ?? null,
                 ]);
 
@@ -101,10 +108,13 @@ class AiTripController extends Controller
                 }
             }
 
+            $this->bootstrapPackageFromAiPlan($trip);
+
             return $trip;
         });
 
-        return redirect()->route('ai.show', $trip->id)->with('success', 'Your AI trip has been generated and saved as draft, You have to complete creating this trip!');
+        return redirect()->route('trip.complete.edit', $trip)
+            ->with('success', 'Your AI trip has been generated as draft. Complete the remaining details and save each tab.');
     }
 
     public function show(Trip $trip)
@@ -114,9 +124,274 @@ class AiTripController extends Controller
         return view('trips.ai.show', compact('trip'));
     }
 
+    public function editCompletion(Trip $trip)
+    {
+        $activeTab = request('tab', 'basics');
+
+        $trip->load([
+            'destination',
+            'destinations',
+            'days.activities.activity',
+            'days.hotel',
+            'packages.includes',
+            'packages.excludes',
+            'packages.highlights',
+            'packages.packageHotels.hotel',
+            'schedules',
+            'images',
+        ]);
+
+        $destinations = Destination::query()->orderBy('name')->get(['id', 'name']);
+        $activities = Activity::query()->orderBy('name')->get(['id', 'name']);
+        $hotels = Hotel::query()->orderBy('name')->get(['id', 'name']);
+
+        return view('trips.ai.complete', compact('trip', 'activeTab', 'destinations', 'activities', 'hotels'));
+    }
+
+    public function saveBasics(Request $request, Trip $trip)
+    {
+        $validated = $request->validate([
+            'destination_id' => 'required|exists:destinations,id',
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'duration_days' => 'required|integer|min:1|max:30',
+            'category' => 'nullable|string|max:255',
+            'max_participants' => 'nullable|integer|min:1',
+            'meeting_point_description' => 'nullable|string',
+            'meeting_point_address' => 'nullable|string|max:255',
+            'status' => 'required|string|in:draft,published',
+        ]);
+
+        $trip->update($validated);
+
+        return redirect()->route('trip.complete.edit', ['trip' => $trip, 'tab' => 'basics'])
+            ->with('success', 'Basics saved successfully.');
+    }
+
+    public function saveDaysActivities(Request $request, Trip $trip)
+    {
+        $validated = $request->validate([
+            'days' => 'required|array|min:1',
+            'days.*.day_number' => 'required|integer|min:1',
+            'days.*.title' => 'nullable|string|max:255',
+            'days.*.description' => 'nullable|string',
+            'days.*.hotel_id' => 'nullable|exists:hotels,id',
+            'days.*.activities' => 'nullable|array',
+            'days.*.activities.*.id' => 'nullable|integer|exists:day_activities,id',
+            'days.*.activities.*.activity_id' => 'nullable|exists:activities,id',
+            'days.*.activities.*.start_time' => 'nullable|date_format:H:i',
+            'days.*.activities.*.end_time' => 'nullable|date_format:H:i',
+            'days.*.activities.*.notes' => 'nullable|string',
+        ]);
+
+        DB::transaction(function () use ($trip, $validated) {
+            foreach ($validated['days'] as $dayPayload) {
+                $tripDay = TripDay::query()->updateOrCreate(
+                    ['trip_id' => $trip->id, 'day_number' => (int) $dayPayload['day_number']],
+                    [
+                        'title' => $dayPayload['title'] ?? null,
+                        'description' => $dayPayload['description'] ?? null,
+                        'hotel_id' => $dayPayload['hotel_id'] ?? null,
+                    ]
+                );
+
+                $sentActivityIds = [];
+
+                foreach (($dayPayload['activities'] ?? []) as $activityPayload) {
+                    if (empty($activityPayload['activity_id'])) {
+                        continue;
+                    }
+
+                    $activity = DayActivity::query()->updateOrCreate(
+                        [
+                            'id' => $activityPayload['id'] ?? null,
+                            'trip_day_id' => $tripDay->id,
+                        ],
+                        [
+                            'activity_id' => (int) $activityPayload['activity_id'],
+                            'start_time' => $activityPayload['start_time'] ?? null,
+                            'end_time' => $activityPayload['end_time'] ?? null,
+                            'notes' => $activityPayload['notes'] ?? null,
+                        ]
+                    );
+
+                    $sentActivityIds[] = $activity->id;
+                }
+
+                if (! empty($sentActivityIds)) {
+                    $tripDay->activities()->whereNotIn('id', $sentActivityIds)->delete();
+                } else {
+                    $tripDay->activities()->delete();
+                }
+            }
+        });
+
+        return redirect()->route('trip.complete.edit', ['trip' => $trip, 'tab' => 'days'])
+            ->with('success', 'Days & activities saved successfully.');
+    }
+
+    public function savePackages(Request $request, Trip $trip)
+    {
+        $validated = $request->validate([
+            'packages' => 'nullable|array',
+            'packages.*.id' => 'nullable|exists:trip_packages,id',
+            'packages.*.name' => 'nullable|string|max:255',
+            'packages.*.price' => 'nullable|numeric|min:0',
+            'packages.*.includes' => 'nullable|string',
+            'packages.*.excludes' => 'nullable|string',
+            'packages.*.highlights' => 'nullable|string',
+            'packages.*.hotels' => 'nullable|array',
+            'packages.*.hotels.*.hotel_id' => 'nullable|exists:hotels,id',
+            'packages.*.hotels.*.room_type' => 'nullable|string|max:255',
+            'packages.*.hotels.*.meal_plan' => 'nullable|string|max:255',
+            'packages.*.hotels.*.amenities' => 'nullable|string',
+        ]);
+
+        DB::transaction(function () use ($trip, $validated) {
+            $keepPackageIds = [];
+
+            foreach (($validated['packages'] ?? []) as $packagePayload) {
+                if (blank($packagePayload['name'] ?? null) && blank($packagePayload['price'] ?? null)) {
+                    continue;
+                }
+
+                $package = TripPackage::query()->updateOrCreate(
+                    [
+                        'id' => $packagePayload['id'] ?? null,
+                        'trip_id' => $trip->id,
+                    ],
+                    [
+                        'name' => $packagePayload['name'] ?? 'Package',
+                        'price' => $packagePayload['price'] ?? 0,
+                    ]
+                );
+
+                $keepPackageIds[] = $package->id;
+
+                $package->includes()->delete();
+                collect(explode(PHP_EOL, (string) ($packagePayload['includes'] ?? '')))
+                    ->map(fn ($line) => trim($line))
+                    ->filter()
+                    ->each(fn ($line) => TripInclude::create(['trip_package_id' => $package->id, 'content' => $line]));
+
+                $package->excludes()->delete();
+                collect(explode(PHP_EOL, (string) ($packagePayload['excludes'] ?? '')))
+                    ->map(fn ($line) => trim($line))
+                    ->filter()
+                    ->each(fn ($line) => TripExclude::create(['trip_package_id' => $package->id, 'content' => $line]));
+
+                $package->highlights()->delete();
+                collect(explode(PHP_EOL, (string) ($packagePayload['highlights'] ?? '')))
+                    ->map(fn ($line) => trim($line))
+                    ->filter()
+                    ->each(fn ($line) => TripHighlight::create([
+                        'trip_package_id' => $package->id,
+                        'title' => Str::limit($line, 255),
+                        'description' => $line,
+                    ]));
+
+                $package->packageHotels()->delete();
+                foreach (($packagePayload['hotels'] ?? []) as $hotelPayload) {
+                    if (empty($hotelPayload['hotel_id'])) {
+                        continue;
+                    }
+
+                    TripPackageHotel::create([
+                        'trip_package_id' => $package->id,
+                        'hotel_id' => (int) $hotelPayload['hotel_id'],
+                        'room_type' => $hotelPayload['room_type'] ?? null,
+                        'meal_plan' => $hotelPayload['meal_plan'] ?? null,
+                        'amenities' => collect(explode(',', (string) ($hotelPayload['amenities'] ?? '')))->map(fn ($item) => trim($item))->filter()->values()->all(),
+                    ]);
+                }
+            }
+
+            $trip->packages()->whereNotIn('id', $keepPackageIds ?: [0])->delete();
+        });
+
+        return redirect()->route('trip.complete.edit', ['trip' => $trip, 'tab' => 'packages'])
+            ->with('success', 'Packages saved successfully.');
+    }
+
+    public function saveSchedules(Request $request, Trip $trip)
+    {
+        $validated = $request->validate([
+            'schedules' => 'nullable|array',
+            'schedules.*.id' => 'nullable|exists:trip_schedules,id',
+            'schedules.*.start_date' => 'required|date',
+            'schedules.*.end_date' => 'required|date',
+            'schedules.*.booking_deadline' => 'nullable|date',
+            'schedules.*.available_seats' => 'nullable|integer|min:0',
+            'schedules.*.price_modifier' => 'nullable|numeric',
+            'schedules.*.status' => 'nullable|string|in:available,full,cancelled',
+        ]);
+
+        DB::transaction(function () use ($trip, $validated) {
+            $keepIds = [];
+
+            foreach (($validated['schedules'] ?? []) as $schedulePayload) {
+                $schedule = TripSchedule::query()->updateOrCreate(
+                    ['id' => $schedulePayload['id'] ?? null, 'trip_id' => $trip->id],
+                    [
+                        'start_date' => $schedulePayload['start_date'],
+                        'end_date' => $schedulePayload['end_date'],
+                        'booking_deadline' => $schedulePayload['booking_deadline'] ?? null,
+                        'available_seats' => $schedulePayload['available_seats'] ?? null,
+                        'price_modifier' => $schedulePayload['price_modifier'] ?? 0,
+                        'status' => $schedulePayload['status'] ?? 'available',
+                    ]
+                );
+
+                $keepIds[] = $schedule->id;
+            }
+
+            $trip->schedules()->whereNotIn('id', $keepIds ?: [0])->delete();
+        });
+
+        return redirect()->route('trip.complete.edit', ['trip' => $trip, 'tab' => 'schedules'])
+            ->with('success', 'Schedules saved successfully.');
+    }
+
+    public function saveImages(Request $request, Trip $trip)
+    {
+        $validated = $request->validate([
+            'cover_image_path' => 'nullable|string|max:255',
+            'images' => 'nullable|array',
+            'images.*.id' => 'nullable|exists:trip_images,id',
+            'images.*.image_path' => 'nullable|string|max:255',
+        ]);
+
+        DB::transaction(function () use ($trip, $validated) {
+            $trip->images()->delete();
+
+            if (! empty($validated['cover_image_path'])) {
+                TripImage::create([
+                    'trip_id' => $trip->id,
+                    'image_path' => $validated['cover_image_path'],
+                    'is_cover' => true,
+                ]);
+            }
+
+            foreach (($validated['images'] ?? []) as $imagePayload) {
+                if (blank($imagePayload['image_path'] ?? null)) {
+                    continue;
+                }
+
+                TripImage::create([
+                    'trip_id' => $trip->id,
+                    'image_path' => $imagePayload['image_path'],
+                    'is_cover' => false,
+                ]);
+            }
+        });
+
+        return redirect()->route('trip.complete.edit', ['trip' => $trip, 'tab' => 'images'])
+            ->with('success', 'Images saved successfully.');
+    }
+
     protected function nextUniqueSlug(string $slugBase): string
     {
-        $slug = $slugBase ?: 'ai-trip'; //for empty name use ai-trip
+        $slug = $slugBase ?: 'ai-trip';
         $counter = 1;
 
         while (Trip::query()->where('slug', $slug)->exists()) {
@@ -125,5 +400,26 @@ class AiTripController extends Controller
         }
 
         return $slug;
+    }
+
+    protected function bootstrapPackageFromAiPlan(Trip $trip): void
+    {
+        if ($trip->packages()->exists()) {
+            return;
+        }
+
+        $package = TripPackage::create([
+            'trip_id' => $trip->id,
+            'name' => 'Standard Package',
+            'price' => 0,
+        ]);
+
+        $hotelIds = $trip->days()->whereNotNull('hotel_id')->pluck('hotel_id')->unique();
+        foreach ($hotelIds as $hotelId) {
+            TripPackageHotel::create([
+                'trip_package_id' => $package->id,
+                'hotel_id' => $hotelId,
+            ]);
+        }
     }
 }

--- a/app/Http/Controllers/TripController.php
+++ b/app/Http/Controllers/TripController.php
@@ -1,60 +1,57 @@
 <?php
 
 namespace App\Http\Controllers;
+
 use App\Models\Trip;
 use App\Models\Activity;
 use App\Models\Guide;
 
 class TripController extends Controller
 {
-    /*
-    Trips dashboard
-    * */
-
-    public function dashboard() {
+    public function dashboard()
+    {
         $systemGuides = Guide::with('user')
-        ->where('status','approved')
-        ->count();
+            ->where('status', 'approved')
+            ->count();
         $guidesRequests = Guide::with('user')
-        ->where('status','pending')
-        ->count();
+            ->where('status', 'pending')
+            ->count();
         $activities = Activity::with('destinations')->count();
-        return view('trips.dashboard', compact(
-            'systemGuides',
-            'guidesRequests',
-            'activities'
-        ));
 
-
+        return view('trips.dashboard', compact('systemGuides', 'guidesRequests', 'activities'));
     }
-    /**
-     * Display a listing of the resource.
-     */
+
     public function index()
     {
         $trips = Trip::with('destination')
+            ->when(request('search'), function ($query, $search) {
+                $query->where(function ($inner) use ($search) {
+                    $inner->where('name', 'like', "%{$search}%")
+                        ->orWhere('description', 'like', "%{$search}%")
+                        ->orWhere('ai_prompt', 'like', "%{$search}%");
+                });
+            })
+            ->when(request('status'), fn ($query, $status) => $query->where('status', $status))
+            ->when(request('destination'), function ($query, $destination) {
+                $query->whereHas('destination', fn ($destinationQuery) => $destinationQuery->where('name', 'like', "%{$destination}%"));
+            })
             ->latest()
             ->get();
-        return view('trips.index',compact('trips'));
+
+        return view('trips.index', compact('trips'));
     }
 
-    /**
-     * show the page to choose the type of planning(manual,AI)
-     */
     public function view()
     {
         return view('trips.view');
     }
 
-
-
     public function destroy(Trip $trip)
-{
-    $trip->delete();
+    {
+        $trip->delete();
 
-    return redirect()
-        ->back()
-        ->with('success', 'Trip deleted successfully');
-}
-
+        return redirect()
+            ->back()
+            ->with('success', 'Trip deleted successfully');
+    }
 }

--- a/app/Http/Requests/TripRequest.php
+++ b/app/Http/Requests/TripRequest.php
@@ -19,6 +19,7 @@ class TripRequest extends FormRequest
         return [
             'destination_id' => 'required|exists:destinations,id',
             'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
             'slug' => [
                 'required',
                 'string',

--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -12,6 +12,7 @@ class Trip extends Model
         'destination_id',
         'name',
         'slug',
+        'description',
         'duration_days',
         'category',
         'max_participants',

--- a/database/migrations/2026_04_02_231000_add_description_to_trips_table.php
+++ b/database/migrations/2026_04_02_231000_add_description_to_trips_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->text('description')->nullable()->after('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->dropColumn('description');
+        });
+    }
+};

--- a/resources/views/trips/ai/complete.blade.php
+++ b/resources/views/trips/ai/complete.blade.php
@@ -1,0 +1,254 @@
+<x-app-layout>
+    <div class="max-w-7xl mx-auto py-8 px-4">
+        <div class="flex items-center justify-between mb-4">
+            <div>
+                <h1 class="text-3xl font-bold">{{ $trip->name }}</h1>
+                <p class="text-sm text-gray-500 mt-1">Trip completion workspace (save each tab separately).</p>
+            </div>
+            <a href="{{ route('trips.index') }}" class="px-4 py-2 border rounded-lg">All Trips</a>
+        </div>
+
+        @if(session('success'))
+            <div class="bg-green-100 text-green-800 p-3 rounded mb-4">{{ session('success') }}</div>
+        @endif
+
+        <div class="bg-yellow-50 border border-yellow-200 text-yellow-800 p-3 rounded mb-4">
+            ⚠️ Important: each tab has its own Save button. You must save before moving to another tab.
+        </div>
+
+        @php
+            $tabs = [
+                'basics' => 'Basics',
+                'days' => 'Days & Activities',
+                'packages' => 'Packages',
+                'schedules' => 'Schedules',
+                'images' => 'Images',
+                'guides' => 'Guides',
+                'transports' => 'Transport',
+            ];
+        @endphp
+
+        <div class="flex flex-wrap gap-2 mb-6">
+            @foreach($tabs as $key => $label)
+                <a href="{{ route('trip.complete.edit', ['trip' => $trip->id, 'tab' => $key]) }}"
+                   class="px-4 py-2 rounded-lg border {{ $activeTab === $key ? 'bg-blue-900 text-white' : 'bg-white text-gray-700' }}">
+                    {{ $label }}
+                </a>
+            @endforeach
+        </div>
+
+        @if($activeTab === 'basics')
+            <form method="POST" action="{{ route('trip.complete.basics', $trip->id) }}" class="bg-white border rounded-xl p-5 space-y-4">
+                @csrf
+                <div class="grid md:grid-cols-2 gap-4">
+                    <div>
+                        <label class="block text-sm">Name</label>
+                        <input name="name" value="{{ old('name', $trip->name) }}" class="w-full border rounded p-2" required>
+                    </div>
+                    <div>
+                        <label class="block text-sm">Destination</label>
+                        <select name="destination_id" class="w-full border rounded p-2" required>
+                            @foreach($destinations as $destination)
+                                <option value="{{ $destination->id }}" @selected(old('destination_id', $trip->destination_id) == $destination->id)>{{ $destination->name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div>
+                        <label class="block text-sm">Duration (days)</label>
+                        <input type="number" name="duration_days" value="{{ old('duration_days', $trip->duration_days) }}" class="w-full border rounded p-2" min="1" required>
+                    </div>
+                    <div>
+                        <label class="block text-sm">Max participants</label>
+                        <input type="number" name="max_participants" value="{{ old('max_participants', $trip->max_participants) }}" class="w-full border rounded p-2" min="1">
+                    </div>
+                    <div>
+                        <label class="block text-sm">Category</label>
+                        <input name="category" value="{{ old('category', $trip->category) }}" class="w-full border rounded p-2">
+                    </div>
+                    <div>
+                        <label class="block text-sm">Status</label>
+                        <select name="status" class="w-full border rounded p-2">
+                            <option value="draft" @selected(old('status', $trip->status)==='draft')>Draft</option>
+                            <option value="published" @selected(old('status', $trip->status)==='published')>Published</option>
+                        </select>
+                    </div>
+                </div>
+                <div>
+                    <label class="block text-sm">Description</label>
+                    <textarea name="description" rows="4" class="w-full border rounded p-2">{{ old('description', $trip->description) }}</textarea>
+                </div>
+                <div>
+                    <label class="block text-sm">Meeting point description</label>
+                    <textarea name="meeting_point_description" rows="2" class="w-full border rounded p-2">{{ old('meeting_point_description', $trip->meeting_point_description) }}</textarea>
+                </div>
+                <div>
+                    <label class="block text-sm">Meeting point address</label>
+                    <input name="meeting_point_address" value="{{ old('meeting_point_address', $trip->meeting_point_address) }}" class="w-full border rounded p-2">
+                </div>
+                <button class="px-5 py-2 bg-blue-600 text-white rounded">Save Basics</button>
+            </form>
+        @endif
+
+        @if($activeTab === 'days')
+            <form method="POST" action="{{ route('trip.complete.days', $trip->id) }}" class="space-y-4">
+                @csrf
+                @foreach($trip->days->sortBy('day_number') as $dayIndex => $day)
+                    <div class="bg-white border rounded-xl p-4 space-y-3">
+                        <h3 class="font-semibold">Day {{ $day->day_number }}</h3>
+                        <input type="hidden" name="days[{{ $dayIndex }}][day_number]" value="{{ $day->day_number }}">
+                        <div class="grid md:grid-cols-2 gap-3">
+                            <div>
+                                <label class="text-sm block">Title</label>
+                                <input name="days[{{ $dayIndex }}][title]" value="{{ old("days.$dayIndex.title", $day->title) }}" class="w-full border rounded p-2">
+                            </div>
+                            <div>
+                                <label class="text-sm block">Hotel</label>
+                                <select name="days[{{ $dayIndex }}][hotel_id]" class="w-full border rounded p-2">
+                                    <option value="">-</option>
+                                    @foreach($hotels as $hotel)
+                                        <option value="{{ $hotel->id }}" @selected(old("days.$dayIndex.hotel_id", $day->hotel_id) == $hotel->id)>{{ $hotel->name }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+                        <div>
+                            <label class="text-sm block">Description</label>
+                            <textarea name="days[{{ $dayIndex }}][description]" rows="2" class="w-full border rounded p-2">{{ old("days.$dayIndex.description", $day->description) }}</textarea>
+                        </div>
+
+                        @foreach($day->activities as $activityIndex => $activity)
+                            <div class="grid md:grid-cols-4 gap-2 p-3 border rounded">
+                                <input type="hidden" name="days[{{ $dayIndex }}][activities][{{ $activityIndex }}][id]" value="{{ $activity->id }}">
+                                <div>
+                                    <label class="text-xs block">Activity</label>
+                                    <select name="days[{{ $dayIndex }}][activities][{{ $activityIndex }}][activity_id]" class="w-full border rounded p-2">
+                                        <option value="">-</option>
+                                        @foreach($activities as $activityOption)
+                                            <option value="{{ $activityOption->id }}" @selected(old("days.$dayIndex.activities.$activityIndex.activity_id", $activity->activity_id) == $activityOption->id)>{{ $activityOption->name }}</option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                                <div>
+                                    <label class="text-xs block">Start</label>
+                                    <input type="time" name="days[{{ $dayIndex }}][activities][{{ $activityIndex }}][start_time]" value="{{ old("days.$dayIndex.activities.$activityIndex.start_time", $activity->start_time ? \Carbon\Carbon::parse($activity->start_time)->format('H:i') : '') }}" class="w-full border rounded p-2">
+                                </div>
+                                <div>
+                                    <label class="text-xs block">End</label>
+                                    <input type="time" name="days[{{ $dayIndex }}][activities][{{ $activityIndex }}][end_time]" value="{{ old("days.$dayIndex.activities.$activityIndex.end_time", $activity->end_time ? \Carbon\Carbon::parse($activity->end_time)->format('H:i') : '') }}" class="w-full border rounded p-2">
+                                </div>
+                                <div>
+                                    <label class="text-xs block">Notes</label>
+                                    <input name="days[{{ $dayIndex }}][activities][{{ $activityIndex }}][notes]" value="{{ old("days.$dayIndex.activities.$activityIndex.notes", $activity->notes) }}" class="w-full border rounded p-2">
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                @endforeach
+                <button class="px-5 py-2 bg-blue-600 text-white rounded">Save Days & Activities</button>
+            </form>
+        @endif
+
+        @if($activeTab === 'packages')
+            <form method="POST" action="{{ route('trip.complete.packages', $trip->id) }}" class="space-y-4">
+                @csrf
+                @forelse($trip->packages as $packageIndex => $package)
+                    <div class="bg-white border rounded-xl p-4 space-y-3">
+                        <input type="hidden" name="packages[{{ $packageIndex }}][id]" value="{{ $package->id }}">
+                        <div class="grid md:grid-cols-2 gap-3">
+                            <input name="packages[{{ $packageIndex }}][name]" value="{{ old("packages.$packageIndex.name", $package->name) }}" class="border rounded p-2" placeholder="Package name" required>
+                            <input type="number" step="0.01" name="packages[{{ $packageIndex }}][price]" value="{{ old("packages.$packageIndex.price", $package->price) }}" class="border rounded p-2" placeholder="Price" required>
+                        </div>
+                        <textarea name="packages[{{ $packageIndex }}][includes]" rows="3" class="w-full border rounded p-2" placeholder="Includes (one item per line)">{{ old("packages.$packageIndex.includes", $package->includes->pluck('content')->implode("\n")) }}</textarea>
+                        <textarea name="packages[{{ $packageIndex }}][excludes]" rows="3" class="w-full border rounded p-2" placeholder="Excludes (one item per line)">{{ old("packages.$packageIndex.excludes", $package->excludes->pluck('content')->implode("\n")) }}</textarea>
+                        <textarea name="packages[{{ $packageIndex }}][highlights]" rows="3" class="w-full border rounded p-2" placeholder="Highlights (one line per highlight)">{{ old("packages.$packageIndex.highlights", $package->highlights->pluck('title')->implode("\n")) }}</textarea>
+
+                        @foreach($package->packageHotels as $hotelIndex => $packageHotel)
+                            <div class="grid md:grid-cols-4 gap-2 p-2 border rounded">
+                                <select name="packages[{{ $packageIndex }}][hotels][{{ $hotelIndex }}][hotel_id]" class="border rounded p-2">
+                                    <option value="">Hotel</option>
+                                    @foreach($hotels as $hotel)
+                                        <option value="{{ $hotel->id }}" @selected(old("packages.$packageIndex.hotels.$hotelIndex.hotel_id", $packageHotel->hotel_id) == $hotel->id)>{{ $hotel->name }}</option>
+                                    @endforeach
+                                </select>
+                                <input name="packages[{{ $packageIndex }}][hotels][{{ $hotelIndex }}][room_type]" value="{{ old("packages.$packageIndex.hotels.$hotelIndex.room_type", $packageHotel->room_type) }}" class="border rounded p-2" placeholder="Room type">
+                                <input name="packages[{{ $packageIndex }}][hotels][{{ $hotelIndex }}][meal_plan]" value="{{ old("packages.$packageIndex.hotels.$hotelIndex.meal_plan", $packageHotel->meal_plan) }}" class="border rounded p-2" placeholder="Meal plan">
+                                <input name="packages[{{ $packageIndex }}][hotels][{{ $hotelIndex }}][amenities]" value="{{ old("packages.$packageIndex.hotels.$hotelIndex.amenities", is_array($packageHotel->amenities) ? implode(', ', $packageHotel->amenities) : '') }}" class="border rounded p-2" placeholder="Amenities comma separated">
+                            </div>
+                        @endforeach
+                    </div>
+                @empty
+                    <div class="bg-white border rounded-xl p-4">
+                        <p class="mb-3">No packages yet. Add one package card manually below:</p>
+                        <input name="packages[0][name]" class="border rounded p-2 w-full mb-2" placeholder="Package name" required>
+                        <input type="number" step="0.01" name="packages[0][price]" class="border rounded p-2 w-full" placeholder="Price" required>
+                    </div>
+                @endforelse
+
+                @php $newIndex = $trip->packages->count(); @endphp
+                <div class="bg-white border border-dashed rounded-xl p-4 space-y-2">
+                    <p class="text-sm text-gray-600">Add package (optional)</p>
+                    <input name="packages[{{ $newIndex }}][name]" class="border rounded p-2 w-full" placeholder="New package name">
+                    <input type="number" step="0.01" name="packages[{{ $newIndex }}][price]" class="border rounded p-2 w-full" placeholder="New package price">
+                    <textarea name="packages[{{ $newIndex }}][includes]" rows="2" class="w-full border rounded p-2" placeholder="Includes (one per line)"></textarea>
+                </div>
+                <button class="px-5 py-2 bg-blue-600 text-white rounded">Save Packages</button>
+            </form>
+        @endif
+
+        @if($activeTab === 'schedules')
+            <form method="POST" action="{{ route('trip.complete.schedules', $trip->id) }}" class="space-y-3">
+                @csrf
+                @forelse($trip->schedules as $index => $schedule)
+                    <div class="grid md:grid-cols-6 gap-2 bg-white border rounded-xl p-3">
+                        <input type="hidden" name="schedules[{{ $index }}][id]" value="{{ $schedule->id }}">
+                        <input type="date" name="schedules[{{ $index }}][start_date]" value="{{ old("schedules.$index.start_date", $schedule->start_date) }}" class="border rounded p-2" required>
+                        <input type="date" name="schedules[{{ $index }}][end_date]" value="{{ old("schedules.$index.end_date", $schedule->end_date) }}" class="border rounded p-2" required>
+                        <input type="date" name="schedules[{{ $index }}][booking_deadline]" value="{{ old("schedules.$index.booking_deadline", $schedule->booking_deadline) }}" class="border rounded p-2">
+                        <input type="number" name="schedules[{{ $index }}][available_seats]" value="{{ old("schedules.$index.available_seats", $schedule->available_seats) }}" class="border rounded p-2" placeholder="Seats">
+                        <input type="number" step="0.01" name="schedules[{{ $index }}][price_modifier]" value="{{ old("schedules.$index.price_modifier", $schedule->price_modifier) }}" class="border rounded p-2" placeholder="Price modifier">
+                        <select name="schedules[{{ $index }}][status]" class="border rounded p-2">
+                            <option value="available" @selected(old("schedules.$index.status", $schedule->status)==='available')>Available</option>
+                            <option value="full" @selected(old("schedules.$index.status", $schedule->status)==='full')>Full</option>
+                            <option value="cancelled" @selected(old("schedules.$index.status", $schedule->status)==='cancelled')>Cancelled</option>
+                        </select>
+                    </div>
+                @empty
+                    <div class="bg-white border rounded-xl p-4 grid md:grid-cols-3 gap-2">
+                        <input type="date" name="schedules[0][start_date]" class="border rounded p-2" required>
+                        <input type="date" name="schedules[0][end_date]" class="border rounded p-2" required>
+                        <select name="schedules[0][status]" class="border rounded p-2">
+                            <option value="available">Available</option>
+                            <option value="full">Full</option>
+                            <option value="cancelled">Cancelled</option>
+                        </select>
+                    </div>
+                @endforelse
+                <button class="px-5 py-2 bg-blue-600 text-white rounded">Save Schedules</button>
+            </form>
+        @endif
+
+        @if($activeTab === 'images')
+            <form method="POST" action="{{ route('trip.complete.images', $trip->id) }}" class="space-y-3 bg-white border rounded-xl p-4">
+                @csrf
+                <div>
+                    <label class="block text-sm">Cover image path</label>
+                    <input name="cover_image_path" value="{{ old('cover_image_path', optional($trip->images->firstWhere('is_cover', true))->image_path) }}" class="w-full border rounded p-2" placeholder="/storage/trips/cover.jpg">
+                </div>
+
+                @php $otherImages = $trip->images->where('is_cover', false)->values(); @endphp
+                @for($i = 0; $i < max(3, $otherImages->count()); $i++)
+                    <input name="images[{{ $i }}][image_path]" value="{{ old("images.$i.image_path", optional($otherImages->get($i))->image_path) }}" class="w-full border rounded p-2" placeholder="Other image path">
+                @endfor
+                <button class="px-5 py-2 bg-blue-600 text-white rounded">Save Images</button>
+            </form>
+        @endif
+
+        @if($activeTab === 'guides')
+            <div class="bg-white border rounded-xl p-6 text-gray-600">Guides form is intentionally left empty for now.</div>
+        @endif
+
+        @if($activeTab === 'transports')
+            <div class="bg-white border rounded-xl p-6 text-gray-600">Transports form is intentionally left empty for now.</div>
+        @endif
+    </div>
+</x-app-layout>

--- a/resources/views/trips/ai/show.blade.php
+++ b/resources/views/trips/ai/show.blade.php
@@ -95,7 +95,7 @@
 
         <div class="trip-actions">
             <a href="{{ route('trips.index') }}" class="btn btn-secondary">← Back to Trips</a>
-            <a href="{{ route('trips.index') }}" class="btn btn-secondary" style="background-color: #22c55e;color:white;">Complete Creating --></a>
+            <a href="{{ route('trip.complete.edit', $trip->id) }}" class="btn btn-secondary" style="background-color: #22c55e;color:white;">Complete Creating --></a>
         </div>
     </div>
 </x-app-layout>

--- a/resources/views/trips/index.blade.php
+++ b/resources/views/trips/index.blade.php
@@ -24,7 +24,7 @@
     {{-- Keyword --}}
     <div class="flex-1 min-w-[200px]">
         <label class="text-sm text-gray-600">Search</label>
-        <input type="text" name="search" value="{{ request('search') }}" placeholder="Search a trip by its name" class="w-full border rounded-lg p-2">
+        <input type="text" name="search" value="{{ request('search') }}" placeholder="Search by name, description, or AI prompt" class="w-full border rounded-lg p-2">
     </div>
 
     
@@ -47,6 +47,7 @@
         <select name="status" class="border rounded-lg p-2" style="margin-bottom:0">
             <option value="">All</option>
             <option value="draft" @selected(request('status')=='draft')>Draft</option>
+            <option value="published" @selected(request('status')=='published')>Published</option>
         </select>
     </div>
 
@@ -77,7 +78,11 @@
                 </p>
                 <p class="text-gray-500 text-sm">Duration: {{ $trip->duration_days }} day(s)</p>
                 <p class="text-gray-500 text-sm">Travelers: {{ $trip->max_participants ?? '-' }}</p>
+                <p class="text-gray-500 text-sm">Status: {{ ucfirst($trip->status) }}</p>
 
+                @if($trip->is_ai_generated && $trip->status === 'draft')
+                    <a href="{{ route('trip.complete.edit', $trip->id) }}" class="inline-block mt-3 bg-yellow-500 hover:bg-yellow-600 text-white px-3 py-2 rounded">Complete Creating</a>
+                @endif
 
                 @if($trip->is_ai_generated)
                 <div class="mt-4 flex justify-between">

--- a/routes/web.php
+++ b/routes/web.php
@@ -235,6 +235,12 @@ Route::delete('/trips/{trip}',[ TripController::class,'destroy'])->name('trip.de
 Route::get('/trips/ai/create',[AiTripController::class,'create'])->name('ai.create');
 Route::post('/trips/ai/generate',[AiTripController::class,'generate'])->name('ai.generate');
 Route::get('/trips/{trip}', [AiTripController::class, 'show'])->name('ai.show');
+Route::get('/trips/{trip}/complete', [AiTripController::class, 'editCompletion'])->name('trip.complete.edit');
+Route::post('/trips/{trip}/complete/basics', [AiTripController::class, 'saveBasics'])->name('trip.complete.basics');
+Route::post('/trips/{trip}/complete/days', [AiTripController::class, 'saveDaysActivities'])->name('trip.complete.days');
+Route::post('/trips/{trip}/complete/packages', [AiTripController::class, 'savePackages'])->name('trip.complete.packages');
+Route::post('/trips/{trip}/complete/schedules', [AiTripController::class, 'saveSchedules'])->name('trip.complete.schedules');
+Route::post('/trips/{trip}/complete/images', [AiTripController::class, 'saveImages'])->name('trip.complete.images');
 
 //Activities routes
 Route::get('/activities',[ActivityController::class,'index'])->name('activities.index');


### PR DESCRIPTION
### Motivation
- Provide an admin-friendly server-rendered workflow to "complete" AI-generated trips (so admins can edit data the AI seeded and finalize a trip without JS/AJAX). 
- Make AI-generated content searchable and editable by storing the AI `trip_description` and exposing it in the trip list search. 
- Surface a clear save-per-tab flow for the creation-completion process and allow admins to manage basics, days/activities, packages, schedules and images before publishing.

### Description
- Added a `description` column to `trips` and made it fillable in `App\Models\Trip`, and added validation in `App\Http\Requests\TripRequest`; migration at `database/migrations/2026_04_02_231000_add_description_to_trips_table.php` was created. 
- Enhanced trip listing search and filters in `App\Http\Controllers\TripController::index` to search `name`, `description`, and `ai_prompt`, and added `status` and `destination` filtering; updated `resources/views/trips/index.blade.php` to reflect the new search placeholder, show `status`, and surface the `Complete Creating` button for AI drafts. 
- Extended the AI generation flow in `App\Http\Controllers\AiTripController` to persist `trip_description` into `trips.description`, auto-bootstrap a default `Standard Package` with AI-suggested hotels, and redirect to a new completion workspace. 
- Implemented a server-rendered completion workspace at `GET /trips/{trip}/complete` with tabbed forms and per-tab POST handlers: `saveBasics`, `saveDaysActivities`, `savePackages`, `saveSchedules`, and `saveImages`, and added the view `resources/views/trips/ai/complete.blade.php`; `trips/ai/show.blade.php` now links to the completion page. 
- Kept `Guides` and `Transports` sections as intentionally empty placeholders for now, and implemented conservative validation and update logic for days, activities, packages, schedules and images (no AJAX; each tab submits and redirects back to the same tab). 

### Testing
- Ran PHP lint checks with `php -l` for `app/Http/Controllers/AiTripController.php`, `app/Http/Controllers/TripController.php`, `app/Http/Requests/TripRequest.php`, `app/Models/Trip.php`, `routes/web.php`, and the new migration and they all reported no syntax errors. 
- Attempted to run the test suite with `php artisan test --filter=Trip --stop-on-failure`, which failed in this environment because `vendor/autoload.php` is missing (CI/development environment issue), so full automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cef7d7dce8832fae6f4bd5b9347200)