### PR TITLE
Clarify Trip destination relations, persist itinerary destinations and add UI for editing multiple destinations

### DIFF
--- a/app/Http/Controllers/AiTripController.php
+++ b/app/Http/Controllers/AiTripController.php
@@ -81,7 +81,7 @@ class AiTripController extends Controller
                 'status' => 'draft',
             ]);
 
-            $trip->destinations()->sync(
+            $trip->itineraryDestinations()->sync(
                 collect($validated['destination_ids'])->values()->mapWithKeys(fn (int $destinationId, int $index) => [
                     $destinationId => ['sort_order' => $index + 1],
                 ])->all()
@@ -119,7 +119,7 @@ class AiTripController extends Controller
 
     public function show(Trip $trip)
     {
-        $trip->load(['destination', 'destinations', 'days.activities.activity', 'days.hotel']);
+        $trip->load(['primaryDestination', 'itineraryDestinations', 'days.activities.activity', 'days.hotel']);
 
         return view('trips.ai.show', compact('trip'));
     }
@@ -129,8 +129,8 @@ class AiTripController extends Controller
         $activeTab = request('tab', 'basics');
 
         $trip->load([
-            'destination',
-            'destinations',
+            'primaryDestination',
+            'itineraryDestinations',
             'days.activities.activity',
             'days.hotel',
             'packages.includes',
@@ -152,6 +152,8 @@ class AiTripController extends Controller
     {
         $validated = $request->validate([
             'destination_id' => 'required|exists:destinations,id',
+            'destination_ids' => 'required|array|min:1',
+            'destination_ids.*' => 'required|integer|exists:destinations,id',
             'name' => 'required|string|max:255',
             'description' => 'nullable|string',
             'duration_days' => 'required|integer|min:1|max:30',
@@ -162,7 +164,25 @@ class AiTripController extends Controller
             'status' => 'required|string|in:draft,published',
         ]);
 
-        $trip->update($validated);
+        $destinationIds = array_values(array_unique(array_map('intval', $validated['destination_ids'])));
+        $primaryDestinationId = (int) $validated['destination_id'];
+
+        if (! in_array($primaryDestinationId, $destinationIds, true)) {
+            array_unshift($destinationIds, $primaryDestinationId);
+        }
+
+        $validated['destination_ids'] = array_values(array_unique([$primaryDestinationId, ...$destinationIds]));
+        $validated['destination_id'] = $primaryDestinationId;
+
+        DB::transaction(function () use ($trip, $validated) {
+            $trip->update(collect($validated)->except('destination_ids')->all());
+
+            $trip->itineraryDestinations()->sync(
+                collect($validated['destination_ids'])->values()->mapWithKeys(fn (int $destinationId, int $index) => [
+                    $destinationId => ['sort_order' => $index + 1],
+                ])->all()
+            );
+        });
 
         return redirect()->route('trip.complete.edit', ['trip' => $trip, 'tab' => 'basics'])
             ->with('success', 'Basics saved successfully.');

--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -63,19 +63,30 @@ class Trip extends Model
             ->withTimestamps();
     }
 
-//primary destination
-  public function destination()
-  {
-    return $this->belongsTo(Destination::class);
-  }
+    // Clear relation name for the primary destination.
+    public function primaryDestination()
+    {
+        return $this->belongsTo(Destination::class, 'destination_id');
+    }
 
-  //other destinations
-  public function destinations()
-  {
-    return $this->belongsToMany(Destination::class, 'trip_destinations')
-        ->withPivot('sort_order')
-        ->orderBy('trip_destinations.sort_order');
-  }
+    // Clear relation name for all itinerary destinations (including primary).
+    public function itineraryDestinations()
+    {
+        return $this->belongsToMany(Destination::class, 'trip_destinations')
+            ->withPivot('sort_order')
+            ->orderBy('trip_destinations.sort_order');
+    }
+
+    // Backward-compatible alias.
+    public function destination()
+    {
+        return $this->primaryDestination();
+    }
+
+    // Backward-compatible alias.
+    public function destinations()
+    {
+        return $this->itineraryDestinations();
+    }
 
 }
-

--- a/resources/views/trips/ai/complete.blade.php
+++ b/resources/views/trips/ai/complete.blade.php
@@ -46,12 +46,43 @@
                         <input name="name" value="{{ old('name', $trip->name) }}" class="w-full border rounded p-2" required>
                     </div>
                     <div>
-                        <label class="block text-sm">Destination</label>
+                        <label class="block text-sm">Primary destination</label>
                         <select name="destination_id" class="w-full border rounded p-2" required>
                             @foreach($destinations as $destination)
                                 <option value="{{ $destination->id }}" @selected(old('destination_id', $trip->destination_id) == $destination->id)>{{ $destination->name }}</option>
                             @endforeach
                         </select>
+                    </div>
+                    <div>
+                        <label class="block text-sm">Itinerary destinations</label>
+                        @php
+                            $selectedDestinationIds = array_map('intval', old(
+                                'destination_ids',
+                                $trip->itineraryDestinations->pluck('id')->all() ?: [$trip->destination_id]
+                            ));
+                            if (empty($selectedDestinationIds)) {
+                                $selectedDestinationIds = [0];
+                            }
+                        @endphp
+                        <div id="itinerary-destinations-repeater" class="space-y-2">
+                            @foreach($selectedDestinationIds as $index => $selectedDestinationId)
+                                <div class="itinerary-destination-row flex items-center gap-2">
+                                    <select name="destination_ids[]" class="flex-1 border rounded p-2" required>
+                                        <option value="">Select destination</option>
+                                        @foreach($destinations as $destination)
+                                            <option value="{{ $destination->id }}" @selected($destination->id === (int) $selectedDestinationId)>
+                                                {{ $destination->name }}
+                                            </option>
+                                        @endforeach
+                                    </select>
+                                    <button type="button" class="remove-destination-row px-3 py-2 border rounded text-red-600">Remove</button>
+                                </div>
+                            @endforeach
+                        </div>
+                        <button type="button" id="add-itinerary-destination-row" class="mt-2 px-3 py-2 border rounded bg-gray-50">
+                            + Add destination
+                        </button>
+                        <p class="text-xs text-gray-500 mt-1">Admin can add/remove itinerary destinations. Primary destination will always be included when saving.</p>
                     </div>
                     <div>
                         <label class="block text-sm">Duration (days)</label>
@@ -238,7 +269,7 @@
                 @php $otherImages = $trip->images->where('is_cover', false)->values(); @endphp
                 @for($i = 0; $i < max(3, $otherImages->count()); $i++)
                     <input name="images[{{ $i }}][image_path]" value="{{ old("images.$i.image_path", optional($otherImages->get($i))->image_path) }}" class="w-full border rounded p-2" placeholder="Other image path">
-                @endfor
+@endfor
                 <button class="px-5 py-2 bg-blue-600 text-white rounded">Save Images</button>
             </form>
         @endif
@@ -251,4 +282,72 @@
             <div class="bg-white border rounded-xl p-6 text-gray-600">Transports form is intentionally left empty for now.</div>
         @endif
     </div>
+
+    @if($activeTab === 'basics')
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                const repeater = document.getElementById('itinerary-destinations-repeater');
+                const addButton = document.getElementById('add-itinerary-destination-row');
+
+                if (!repeater || !addButton) return;
+
+                const destinationOptions = @json($destinations->map(fn ($destination) => [
+                    'id' => $destination->id,
+                    'name' => $destination->name,
+                ])->values());
+
+                const buildRow = () => {
+                    const row = document.createElement('div');
+                    row.className = 'itinerary-destination-row flex items-center gap-2';
+
+                    const select = document.createElement('select');
+                    select.name = 'destination_ids[]';
+                    select.required = true;
+                    select.className = 'flex-1 border rounded p-2';
+
+                    const placeholderOption = document.createElement('option');
+                    placeholderOption.value = '';
+                    placeholderOption.textContent = 'Select destination';
+                    select.appendChild(placeholderOption);
+
+                    destinationOptions.forEach((destination) => {
+                        const option = document.createElement('option');
+                        option.value = destination.id;
+                        option.textContent = destination.name;
+                        select.appendChild(option);
+                    });
+
+                    const removeButton = document.createElement('button');
+                    removeButton.type = 'button';
+                    removeButton.className = 'remove-destination-row px-3 py-2 border rounded text-red-600';
+                    removeButton.textContent = 'Remove';
+
+                    row.appendChild(select);
+                    row.appendChild(removeButton);
+
+                    return row;
+                };
+
+                addButton.addEventListener('click', function () {
+                    repeater.appendChild(buildRow());
+                });
+
+                repeater.addEventListener('click', function (event) {
+                    const removeButton = event.target.closest('.remove-destination-row');
+
+                    if (!removeButton) return;
+
+                    const row = removeButton.closest('.itinerary-destination-row');
+                    if (!row) return;
+
+                    if (repeater.querySelectorAll('.itinerary-destination-row').length === 1) {
+                        row.querySelector('select').value = '';
+                        return;
+                    }
+
+                    row.remove();
+                });
+            });
+        </script>
+    @endif
 </x-app-layout>

--- a/resources/views/trips/ai/show.blade.php
+++ b/resources/views/trips/ai/show.blade.php
@@ -12,7 +12,7 @@
         <div class="trip-header">
             <h1>{{ $trip->name }}</h1>
             <div class="trip-meta">
-                <div class="trip-meta-item"><strong>📍 Destinations:</strong> <span>{{ $trip->destinations->pluck('name')->join(' • ') ?: $trip->destination?->name }}</span></div>
+                <div class="trip-meta-item"><strong>📍 Destinations:</strong> <span>{{ $trip->itineraryDestinations->pluck('name')->join(' • ') ?: $trip->primaryDestination?->name }}</span></div>
                 <div class="trip-meta-item"><strong>📅 Duration:</strong> <span>{{ $trip->duration_days }} days</span></div>
                 <div class="trip-meta-item"><strong>👥 Max Participants:</strong> <span>{{ $trip->max_participants ?? '-' }}</span></div>
                 <div class="trip-meta-item"><strong>🤖 Source:</strong> <span>AI + DB Catalog</span></div>


### PR DESCRIPTION
### Motivation
- Make the Trip model relation names clearer for primary vs all itinerary destinations to avoid ambiguity when reading and using relations. 
- Persist and manage ordered itinerary destinations separately from the primary destination so AI-generated and manual edits include a full itinerary order. 
- Expose a simple admin UI to add/remove itinerary destinations and ensure the primary destination is always included when saving.

### Description
- Renamed relation methods on `Trip` to `primaryDestination()` and `itineraryDestinations()` and added backward-compatible aliases `destination()` and `destinations()` that delegate to the new names. 
- Updated `AiTripController` to load and operate on `primaryDestination` / `itineraryDestinations` (create/sync when generating trips and when saving basics) and wrapped updates to destinations and trip fields in a `DB::transaction`. 
- Extended `saveBasics` validation to require `destination_ids` array and ensure the selected `destination_id` is included and ordered as primary before syncing via `itineraryDestinations()->sync(...)`. 
- Updated the AI trip completion view `trips/ai/complete.blade.php` to add an itinerary destinations repeater UI with server-side population (`destination_ids[]`) and client-side JS to add/remove rows, and adjusted labels to indicate the primary destination. 
- Updated `trips/ai/show.blade.php` to display the itinerary destination list via `itineraryDestinations` falling back to `primaryDestination`.

### Testing
- Ran the existing PHPUnit suite with `./vendor/bin/phpunit` and the full test suite completed successfully with no failures. 
- Performed the automated feature tests that exercise trip creation, editing basics, and syncing destinations and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf04dbb078832fa45629083b9c59d2)