### PR TITLE
Keep AI trip completion status locked to draft

### DIFF
--- a/app/Http/Controllers/AiTripController.php
+++ b/app/Http/Controllers/AiTripController.php
@@ -161,7 +161,6 @@ class AiTripController extends Controller
             'max_participants' => 'nullable|integer|min:1',
             'meeting_point_description' => 'nullable|string',
             'meeting_point_address' => 'nullable|string|max:255',
-            'status' => 'required|string|in:draft,published',
         ]);
 
         $destinationIds = array_values(array_unique(array_map('intval', $validated['destination_ids'])));
@@ -175,7 +174,12 @@ class AiTripController extends Controller
         $validated['destination_id'] = $primaryDestinationId;
 
         DB::transaction(function () use ($trip, $validated) {
-            $trip->update(collect($validated)->except('destination_ids')->all());
+            $trip->update(
+                collect($validated)
+                    ->except('destination_ids')
+                    ->put('status', 'draft')
+                    ->all()
+            );
 
             $trip->itineraryDestinations()->sync(
                 collect($validated['destination_ids'])->values()->mapWithKeys(fn (int $destinationId, int $index) => [

--- a/resources/views/trips/ai/complete.blade.php
+++ b/resources/views/trips/ai/complete.blade.php
@@ -98,10 +98,8 @@
                     </div>
                     <div>
                         <label class="block text-sm">Status</label>
-                        <select name="status" class="w-full border rounded p-2">
-                            <option value="draft" @selected(old('status', $trip->status)==='draft')>Draft</option>
-                            <option value="published" @selected(old('status', $trip->status)==='published')>Published</option>
-                        </select>
+                        <input value="Draft" class="w-full border rounded p-2 bg-gray-100 text-gray-600" disabled>
+                        <p class="text-xs text-gray-500 mt-1">Status stays Draft here until final Publish step.</p>
                     </div>
                 </div>
                 <div>


### PR DESCRIPTION
### Motivation
- Prevent admins from accidentally publishing AI-generated trips during the intermediate completion workflow so the trip remains `draft` until a deliberate final publish step (ensuring guides/drivers and other data are completed first).

### Description
- Force `status` to `'draft'` when saving basics in `AiTripController::saveBasics` by removing the editable `status` validation and writing `->put('status', 'draft')` into the persisted payload.
- Replace the editable status `<select>` in `resources/views/trips/ai/complete.blade.php` with a disabled read-only `Draft` indicator and a short explanatory note.

### Testing
- Ran PHP syntax checks with `php -l app/Http/Controllers/AiTripController.php` and `php -l resources/views/trips/ai/complete.blade.php`, both returned "No syntax errors detected."

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d525f653cc832f9fdbe096d5906065)