### PR TITLE
Add repeater UX for AI trip packages, schedules, and images

### DIFF
--- a/app/Http/Controllers/AiTripController.php
+++ b/app/Http/Controllers/AiTripController.php
@@ -272,9 +272,12 @@ class AiTripController extends Controller
             'packages.*.id' => 'nullable|exists:trip_packages,id',
             'packages.*.name' => 'nullable|string|max:255',
             'packages.*.price' => 'nullable|numeric|min:0',
-            'packages.*.includes' => 'nullable|string',
-            'packages.*.excludes' => 'nullable|string',
-            'packages.*.highlights' => 'nullable|string',
+            'packages.*.includes' => 'nullable',
+            'packages.*.includes.*' => 'nullable|string|max:255',
+            'packages.*.excludes' => 'nullable',
+            'packages.*.excludes.*' => 'nullable|string|max:255',
+            'packages.*.highlights' => 'nullable',
+            'packages.*.highlights.*' => 'nullable|string|max:255',
             'packages.*.hotels' => 'nullable|array',
             'packages.*.hotels.*.hotel_id' => 'nullable|exists:hotels,id',
             'packages.*.hotels.*.room_type' => 'nullable|string|max:255',
@@ -306,19 +309,19 @@ class AiTripController extends Controller
                 $keepPackageIds[] = $package->id;
 
                 $package->includes()->delete();
-                collect(explode(PHP_EOL, (string) ($packagePayload['includes'] ?? '')))
+                collect($this->normalizeRepeaterInput($packagePayload['includes'] ?? []))
                     ->map(fn ($line) => trim($line))
                     ->filter()
                     ->each(fn ($line) => TripInclude::create(['trip_package_id' => $package->id, 'content' => $line]));
 
                 $package->excludes()->delete();
-                collect(explode(PHP_EOL, (string) ($packagePayload['excludes'] ?? '')))
+                collect($this->normalizeRepeaterInput($packagePayload['excludes'] ?? []))
                     ->map(fn ($line) => trim($line))
                     ->filter()
                     ->each(fn ($line) => TripExclude::create(['trip_package_id' => $package->id, 'content' => $line]));
 
                 $package->highlights()->delete();
-                collect(explode(PHP_EOL, (string) ($packagePayload['highlights'] ?? '')))
+                collect($this->normalizeRepeaterInput($packagePayload['highlights'] ?? []))
                     ->map(fn ($line) => trim($line))
                     ->filter()
                     ->each(fn ($line) => TripHighlight::create([
@@ -499,5 +502,18 @@ class AiTripController extends Controller
             'end_time' => $activityPayload['end_time'] ?? null,
             'notes' => $activityPayload['notes'] ?? null,
         ];
+    }
+
+    protected function normalizeRepeaterInput(mixed $value): array
+    {
+        if (is_array($value)) {
+            return array_values($value);
+        }
+
+        if (is_string($value)) {
+            return explode(PHP_EOL, $value);
+        }
+
+        return [];
     }
 }

--- a/resources/views/trips/ai/complete.blade.php
+++ b/resources/views/trips/ai/complete.blade.php
@@ -183,43 +183,109 @@
         @if($activeTab === 'packages')
             <form method="POST" action="{{ route('trip.complete.packages', $trip->id) }}" class="space-y-4">
                 @csrf
-                @forelse($trip->packages as $packageIndex => $package)
-                    <div class="bg-white border rounded-xl p-4 space-y-3">
-                        <input type="hidden" name="packages[{{ $packageIndex }}][id]" value="{{ $package->id }}">
-                        <div class="grid md:grid-cols-2 gap-3">
-                            <input name="packages[{{ $packageIndex }}][name]" value="{{ old("packages.$packageIndex.name", $package->name) }}" class="border rounded p-2" placeholder="Package name" required>
-                            <input type="number" step="0.01" name="packages[{{ $packageIndex }}][price]" value="{{ old("packages.$packageIndex.price", $package->price) }}" class="border rounded p-2" placeholder="Price" required>
-                        </div>
-                        <textarea name="packages[{{ $packageIndex }}][includes]" rows="3" class="w-full border rounded p-2" placeholder="Includes (one item per line)">{{ old("packages.$packageIndex.includes", $package->includes->pluck('content')->implode("\n")) }}</textarea>
-                        <textarea name="packages[{{ $packageIndex }}][excludes]" rows="3" class="w-full border rounded p-2" placeholder="Excludes (one item per line)">{{ old("packages.$packageIndex.excludes", $package->excludes->pluck('content')->implode("\n")) }}</textarea>
-                        <textarea name="packages[{{ $packageIndex }}][highlights]" rows="3" class="w-full border rounded p-2" placeholder="Highlights (one line per highlight)">{{ old("packages.$packageIndex.highlights", $package->highlights->pluck('title')->implode("\n")) }}</textarea>
+                @php
+                    $packages = old('packages', $trip->packages->map(function ($package) {
+                        return [
+                            'id' => $package->id,
+                            'name' => $package->name,
+                            'price' => $package->price,
+                            'includes' => $package->includes->pluck('content')->values()->all(),
+                            'excludes' => $package->excludes->pluck('content')->values()->all(),
+                            'highlights' => $package->highlights->pluck('title')->values()->all(),
+                            'hotels' => $package->packageHotels->map(function ($packageHotel) {
+                                return [
+                                    'hotel_id' => $packageHotel->hotel_id,
+                                    'room_type' => $packageHotel->room_type,
+                                    'meal_plan' => $packageHotel->meal_plan,
+                                    'amenities' => is_array($packageHotel->amenities) ? implode(', ', $packageHotel->amenities) : '',
+                                    'notes' => $packageHotel->notes,
+                                    'hotel_name' => optional($packageHotel->hotel)->name,
+                                ];
+                            })->values()->all(),
+                        ];
+                    })->values()->all());
+                @endphp
 
-                        @foreach($package->packageHotels as $hotelIndex => $packageHotel)
-                            <div class="grid md:grid-cols-4 gap-2 p-2 border rounded">
-                                <input type="hidden" name="packages[{{ $packageIndex }}][hotels][{{ $hotelIndex }}][hotel_id]" value="{{ $packageHotel->hotel_id }}">
-                                <input value="{{ optional($packageHotel->hotel)->name }}" class="border rounded p-2 bg-gray-100" readonly>
-                                <input name="packages[{{ $packageIndex }}][hotels][{{ $hotelIndex }}][room_type]" value="{{ old("packages.$packageIndex.hotels.$hotelIndex.room_type", $packageHotel->room_type) }}" class="border rounded p-2" placeholder="Room type">
-                                <input name="packages[{{ $packageIndex }}][hotels][{{ $hotelIndex }}][meal_plan]" value="{{ old("packages.$packageIndex.hotels.$hotelIndex.meal_plan", $packageHotel->meal_plan) }}" class="border rounded p-2" placeholder="Meal plan">
-                                <input name="packages[{{ $packageIndex }}][hotels][{{ $hotelIndex }}][amenities]" value="{{ old("packages.$packageIndex.hotels.$hotelIndex.amenities", is_array($packageHotel->amenities) ? implode(', ', $packageHotel->amenities) : '') }}" class="border rounded p-2" placeholder="Amenities comma separated">
-                                <textarea name="packages[{{ $packageIndex }}][hotels][{{ $hotelIndex }}][notes]" class="border rounded p-2 md:col-span-4" rows="2" placeholder="Notes / package differentiation">{{ old("packages.$packageIndex.hotels.$hotelIndex.notes", $packageHotel->notes) }}</textarea>
+                <div id="packages-repeater" class="space-y-4">
+                    @forelse($packages as $packageIndex => $package)
+                        <div class="package-card bg-white border rounded-xl p-4 space-y-3" data-package-index="{{ $packageIndex }}">
+                            <div class="flex justify-between items-start gap-3">
+                                <h3 class="font-semibold text-gray-800">Package #<span class="package-seq">{{ $packageIndex + 1 }}</span></h3>
+                                <button type="button" class="remove-package-btn px-3 py-2 border rounded text-red-600">Remove package</button>
                             </div>
-                        @endforeach
-                    </div>
-                @empty
-                    <div class="bg-white border rounded-xl p-4">
-                        <p class="mb-3">No packages yet. Add one package card manually below:</p>
-                        <input name="packages[0][name]" class="border rounded p-2 w-full mb-2" placeholder="Package name" required>
-                        <input type="number" step="0.01" name="packages[0][price]" class="border rounded p-2 w-full" placeholder="Price" required>
-                    </div>
-                @endforelse
 
-                @php $newIndex = $trip->packages->count(); @endphp
-                <div class="bg-white border border-dashed rounded-xl p-4 space-y-2">
-                    <p class="text-sm text-gray-600">Add package (optional)</p>
-                    <input name="packages[{{ $newIndex }}][name]" class="border rounded p-2 w-full" placeholder="New package name">
-                    <input type="number" step="0.01" name="packages[{{ $newIndex }}][price]" class="border rounded p-2 w-full" placeholder="New package price">
-                    <textarea name="packages[{{ $newIndex }}][includes]" rows="2" class="w-full border rounded p-2" placeholder="Includes (one per line)"></textarea>
+                            <input type="hidden" name="packages[{{ $packageIndex }}][id]" value="{{ $package['id'] ?? '' }}">
+                            <div class="grid md:grid-cols-2 gap-3">
+                                <input name="packages[{{ $packageIndex }}][name]" value="{{ $package['name'] ?? '' }}" class="border rounded p-2" placeholder="Package name" required>
+                                <input type="number" step="0.01" name="packages[{{ $packageIndex }}][price]" value="{{ $package['price'] ?? '' }}" class="border rounded p-2" placeholder="Price" required>
+                            </div>
+
+                            <div class="grid md:grid-cols-3 gap-3">
+                                <div class="border rounded p-3 space-y-2">
+                                    <div class="flex justify-between items-center">
+                                        <label class="text-sm font-medium">Includes</label>
+                                        <button type="button" class="add-item-btn text-xs px-2 py-1 border rounded" data-list-type="includes">+ Add</button>
+                                    </div>
+                                    <div class="items-list space-y-2" data-list-type="includes">
+                                        @foreach(($package['includes'] ?? []) as $itemIndex => $include)
+                                            <div class="flex gap-2">
+                                                <input name="packages[{{ $packageIndex }}][includes][]" value="{{ $include }}" class="w-full border rounded p-2" placeholder="Include item">
+                                                <button type="button" class="remove-item-btn px-2 border rounded text-red-600">×</button>
+                                            </div>
+                                        @endforeach
+                                    </div>
+                                </div>
+
+                                <div class="border rounded p-3 space-y-2">
+                                    <div class="flex justify-between items-center">
+                                        <label class="text-sm font-medium">Excludes</label>
+                                        <button type="button" class="add-item-btn text-xs px-2 py-1 border rounded" data-list-type="excludes">+ Add</button>
+                                    </div>
+                                    <div class="items-list space-y-2" data-list-type="excludes">
+                                        @foreach(($package['excludes'] ?? []) as $itemIndex => $exclude)
+                                            <div class="flex gap-2">
+                                                <input name="packages[{{ $packageIndex }}][excludes][]" value="{{ $exclude }}" class="w-full border rounded p-2" placeholder="Exclude item">
+                                                <button type="button" class="remove-item-btn px-2 border rounded text-red-600">×</button>
+                                            </div>
+                                        @endforeach
+                                    </div>
+                                </div>
+
+                                <div class="border rounded p-3 space-y-2">
+                                    <div class="flex justify-between items-center">
+                                        <label class="text-sm font-medium">Highlights</label>
+                                        <button type="button" class="add-item-btn text-xs px-2 py-1 border rounded" data-list-type="highlights">+ Add</button>
+                                    </div>
+                                    <div class="items-list space-y-2" data-list-type="highlights">
+                                        @foreach(($package['highlights'] ?? []) as $itemIndex => $highlight)
+                                            <div class="flex gap-2">
+                                                <input name="packages[{{ $packageIndex }}][highlights][]" value="{{ $highlight }}" class="w-full border rounded p-2" placeholder="Highlight item">
+                                                <button type="button" class="remove-item-btn px-2 border rounded text-red-600">×</button>
+                                            </div>
+                                        @endforeach
+                                    </div>
+                                </div>
+                            </div>
+
+                            @foreach(($package['hotels'] ?? []) as $hotelIndex => $packageHotel)
+                                <div class="grid md:grid-cols-4 gap-2 p-2 border rounded">
+                                    <input type="hidden" name="packages[{{ $packageIndex }}][hotels][{{ $hotelIndex }}][hotel_id]" value="{{ $packageHotel['hotel_id'] ?? '' }}">
+                                    <input value="{{ $packageHotel['hotel_name'] ?? '' }}" class="border rounded p-2 bg-gray-100" readonly>
+                                    <input name="packages[{{ $packageIndex }}][hotels][{{ $hotelIndex }}][room_type]" value="{{ $packageHotel['room_type'] ?? '' }}" class="border rounded p-2" placeholder="Room type">
+                                    <input name="packages[{{ $packageIndex }}][hotels][{{ $hotelIndex }}][meal_plan]" value="{{ $packageHotel['meal_plan'] ?? '' }}" class="border rounded p-2" placeholder="Meal plan">
+                                    <input name="packages[{{ $packageIndex }}][hotels][{{ $hotelIndex }}][amenities]" value="{{ $packageHotel['amenities'] ?? '' }}" class="border rounded p-2" placeholder="Amenities comma separated">
+                                    <textarea name="packages[{{ $packageIndex }}][hotels][{{ $hotelIndex }}][notes]" class="border rounded p-2 md:col-span-4" rows="2" placeholder="Notes / package differentiation">{{ $packageHotel['notes'] ?? '' }}</textarea>
+                                </div>
+                            @endforeach
+                        </div>
+                    @empty
+                        <div class="bg-white border rounded-xl p-4">
+                            <p class="mb-2 text-sm text-gray-600">No packages yet. Click "+ Add package".</p>
+                        </div>
+                    @endforelse
                 </div>
+
+                <button type="button" id="add-package-btn" class="px-4 py-2 border rounded bg-gray-50">+ Add package</button>
                 <button class="px-5 py-2 bg-blue-600 text-white rounded">Save Packages</button>
             </form>
         @endif
@@ -227,31 +293,45 @@
         @if($activeTab === 'schedules')
             <form method="POST" action="{{ route('trip.complete.schedules', $trip->id) }}" class="space-y-3">
                 @csrf
-                @forelse($trip->schedules as $index => $schedule)
-                    <div class="grid md:grid-cols-6 gap-2 bg-white border rounded-xl p-3">
-                        <input type="hidden" name="schedules[{{ $index }}][id]" value="{{ $schedule->id }}">
-                        <input type="date" name="schedules[{{ $index }}][start_date]" value="{{ old("schedules.$index.start_date", $schedule->start_date) }}" class="border rounded p-2" required>
-                        <input type="date" name="schedules[{{ $index }}][end_date]" value="{{ old("schedules.$index.end_date", $schedule->end_date) }}" class="border rounded p-2" required>
-                        <input type="date" name="schedules[{{ $index }}][booking_deadline]" value="{{ old("schedules.$index.booking_deadline", $schedule->booking_deadline) }}" class="border rounded p-2">
-                        <input type="number" name="schedules[{{ $index }}][available_seats]" value="{{ old("schedules.$index.available_seats", $schedule->available_seats) }}" class="border rounded p-2" placeholder="Seats">
-                        <input type="number" step="0.01" name="schedules[{{ $index }}][price_modifier]" value="{{ old("schedules.$index.price_modifier", $schedule->price_modifier) }}" class="border rounded p-2" placeholder="Price modifier">
-                        <select name="schedules[{{ $index }}][status]" class="border rounded p-2">
-                            <option value="available" @selected(old("schedules.$index.status", $schedule->status)==='available')>Available</option>
-                            <option value="full" @selected(old("schedules.$index.status", $schedule->status)==='full')>Full</option>
-                            <option value="cancelled" @selected(old("schedules.$index.status", $schedule->status)==='cancelled')>Cancelled</option>
-                        </select>
-                    </div>
-                @empty
-                    <div class="bg-white border rounded-xl p-4 grid md:grid-cols-3 gap-2">
-                        <input type="date" name="schedules[0][start_date]" class="border rounded p-2" required>
-                        <input type="date" name="schedules[0][end_date]" class="border rounded p-2" required>
-                        <select name="schedules[0][status]" class="border rounded p-2">
-                            <option value="available">Available</option>
-                            <option value="full">Full</option>
-                            <option value="cancelled">Cancelled</option>
-                        </select>
-                    </div>
-                @endforelse
+                @php
+                    $schedules = old('schedules', $trip->schedules->map(fn ($schedule) => [
+                        'id' => $schedule->id,
+                        'start_date' => $schedule->start_date,
+                        'end_date' => $schedule->end_date,
+                        'booking_deadline' => $schedule->booking_deadline,
+                        'available_seats' => $schedule->available_seats,
+                        'price_modifier' => $schedule->price_modifier,
+                        'status' => $schedule->status,
+                    ])->values()->all());
+                @endphp
+                <div id="schedules-repeater" class="space-y-3">
+                    @forelse($schedules as $index => $schedule)
+                        <div class="schedule-row bg-white border rounded-xl p-3 space-y-2" data-schedule-index="{{ $index }}">
+                            <div class="flex justify-between">
+                                <h3 class="font-semibold text-sm text-gray-700">Schedule #<span class="schedule-seq">{{ $index + 1 }}</span></h3>
+                                <button type="button" class="remove-schedule-btn px-2 py-1 border rounded text-red-600">Remove</button>
+                            </div>
+                            <input type="hidden" name="schedules[{{ $index }}][id]" value="{{ $schedule['id'] ?? '' }}">
+                            <div class="grid md:grid-cols-6 gap-2">
+                                <input type="date" name="schedules[{{ $index }}][start_date]" value="{{ $schedule['start_date'] ?? '' }}" class="border rounded p-2" required>
+                                <input type="date" name="schedules[{{ $index }}][end_date]" value="{{ $schedule['end_date'] ?? '' }}" class="border rounded p-2" required>
+                                <input type="date" name="schedules[{{ $index }}][booking_deadline]" value="{{ $schedule['booking_deadline'] ?? '' }}" class="border rounded p-2">
+                                <input type="number" name="schedules[{{ $index }}][available_seats]" value="{{ $schedule['available_seats'] ?? '' }}" class="border rounded p-2" placeholder="Seats">
+                                <input type="number" step="0.01" name="schedules[{{ $index }}][price_modifier]" value="{{ $schedule['price_modifier'] ?? '' }}" class="border rounded p-2" placeholder="Price modifier">
+                                <select name="schedules[{{ $index }}][status]" class="border rounded p-2">
+                                    <option value="available" @selected(($schedule['status'] ?? 'available')==='available')>Available</option>
+                                    <option value="full" @selected(($schedule['status'] ?? '')==='full')>Full</option>
+                                    <option value="cancelled" @selected(($schedule['status'] ?? '')==='cancelled')>Cancelled</option>
+                                </select>
+                            </div>
+                        </div>
+                    @empty
+                        <div class="bg-white border rounded-xl p-4 text-sm text-gray-600">
+                            No schedules yet. Click "+ Add schedule".
+                        </div>
+                    @endforelse
+                </div>
+                <button type="button" id="add-schedule-btn" class="px-4 py-2 border rounded bg-gray-50">+ Add schedule</button>
                 <button class="px-5 py-2 bg-blue-600 text-white rounded">Save Schedules</button>
             </form>
         @endif
@@ -264,10 +344,27 @@
                     <input name="cover_image_path" value="{{ old('cover_image_path', optional($trip->images->firstWhere('is_cover', true))->image_path) }}" class="w-full border rounded p-2" placeholder="/storage/trips/cover.jpg">
                 </div>
 
-                @php $otherImages = $trip->images->where('is_cover', false)->values(); @endphp
-                @for($i = 0; $i < max(3, $otherImages->count()); $i++)
-                    <input name="images[{{ $i }}][image_path]" value="{{ old("images.$i.image_path", optional($otherImages->get($i))->image_path) }}" class="w-full border rounded p-2" placeholder="Other image path">
-@endfor
+                @php
+                    $otherImages = old('images', $trip->images->where('is_cover', false)->values()->map(fn ($image) => [
+                        'id' => $image->id,
+                        'image_path' => $image->image_path,
+                    ])->all());
+                @endphp
+                <div class="flex justify-between items-center">
+                    <label class="block text-sm">Gallery images</label>
+                    <button type="button" id="add-image-btn" class="px-3 py-1 border rounded text-sm">+ Add image</button>
+                </div>
+                <div id="images-repeater" class="space-y-2">
+                    @forelse($otherImages as $index => $image)
+                        <div class="image-row flex items-center gap-2" data-image-index="{{ $index }}">
+                            <input type="hidden" name="images[{{ $index }}][id]" value="{{ $image['id'] ?? '' }}">
+                            <input name="images[{{ $index }}][image_path]" value="{{ $image['image_path'] ?? '' }}" class="w-full border rounded p-2" placeholder="Other image path">
+                            <button type="button" class="remove-image-btn px-3 py-2 border rounded text-red-600">Remove</button>
+                        </div>
+                    @empty
+                        <p class="text-sm text-gray-600" id="images-empty-note">No images yet. Click "+ Add image".</p>
+                    @endforelse
+                </div>
                 <button class="px-5 py-2 bg-blue-600 text-white rounded">Save Images</button>
             </form>
         @endif
@@ -344,6 +441,197 @@
                     }
 
                     row.remove();
+                });
+            });
+        </script>
+    @endif
+
+    @if($activeTab === 'packages')
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                const repeater = document.getElementById('packages-repeater');
+                const addPackageBtn = document.getElementById('add-package-btn');
+                if (!repeater || !addPackageBtn) return;
+
+                const renumberPackages = () => {
+                    repeater.querySelectorAll('.package-card').forEach((card, packageIndex) => {
+                        card.dataset.packageIndex = packageIndex;
+                        const seq = card.querySelector('.package-seq');
+                        if (seq) seq.textContent = packageIndex + 1;
+
+                        card.querySelectorAll('input, textarea, select').forEach((field) => {
+                            if (!field.name) return;
+                            field.name = field.name.replace(/packages\[\d+]/, `packages[${packageIndex}]`);
+                        });
+                    });
+                };
+
+                const itemRow = (packageIndex, listType) => `
+                    <div class="flex gap-2">
+                        <input name="packages[${packageIndex}][${listType}][]" class="w-full border rounded p-2" placeholder="${listType.slice(0, -1)} item">
+                        <button type="button" class="remove-item-btn px-2 border rounded text-red-600">×</button>
+                    </div>
+                `;
+
+                const packageTemplate = () => {
+                    const nextIndex = repeater.querySelectorAll('.package-card').length;
+                    return `
+                        <div class="package-card bg-white border rounded-xl p-4 space-y-3" data-package-index="${nextIndex}">
+                            <div class="flex justify-between items-start gap-3">
+                                <h3 class="font-semibold text-gray-800">Package #<span class="package-seq">${nextIndex + 1}</span></h3>
+                                <button type="button" class="remove-package-btn px-3 py-2 border rounded text-red-600">Remove package</button>
+                            </div>
+                            <input type="hidden" name="packages[${nextIndex}][id]" value="">
+                            <div class="grid md:grid-cols-2 gap-3">
+                                <input name="packages[${nextIndex}][name]" class="border rounded p-2" placeholder="Package name" required>
+                                <input type="number" step="0.01" name="packages[${nextIndex}][price]" class="border rounded p-2" placeholder="Price" required>
+                            </div>
+                            <div class="grid md:grid-cols-3 gap-3">
+                                <div class="border rounded p-3 space-y-2">
+                                    <div class="flex justify-between items-center">
+                                        <label class="text-sm font-medium">Includes</label>
+                                        <button type="button" class="add-item-btn text-xs px-2 py-1 border rounded" data-list-type="includes">+ Add</button>
+                                    </div>
+                                    <div class="items-list space-y-2" data-list-type="includes"></div>
+                                </div>
+                                <div class="border rounded p-3 space-y-2">
+                                    <div class="flex justify-between items-center">
+                                        <label class="text-sm font-medium">Excludes</label>
+                                        <button type="button" class="add-item-btn text-xs px-2 py-1 border rounded" data-list-type="excludes">+ Add</button>
+                                    </div>
+                                    <div class="items-list space-y-2" data-list-type="excludes"></div>
+                                </div>
+                                <div class="border rounded p-3 space-y-2">
+                                    <div class="flex justify-between items-center">
+                                        <label class="text-sm font-medium">Highlights</label>
+                                        <button type="button" class="add-item-btn text-xs px-2 py-1 border rounded" data-list-type="highlights">+ Add</button>
+                                    </div>
+                                    <div class="items-list space-y-2" data-list-type="highlights"></div>
+                                </div>
+                            </div>
+                        </div>
+                    `;
+                };
+
+                addPackageBtn.addEventListener('click', function () {
+                    repeater.insertAdjacentHTML('beforeend', packageTemplate());
+                });
+
+                repeater.addEventListener('click', function (event) {
+                    const addItemButton = event.target.closest('.add-item-btn');
+                    if (addItemButton) {
+                        const packageCard = addItemButton.closest('.package-card');
+                        const listType = addItemButton.dataset.listType;
+                        const list = packageCard.querySelector(`.items-list[data-list-type="${listType}"]`);
+                        list.insertAdjacentHTML('beforeend', itemRow(packageCard.dataset.packageIndex, listType));
+                        return;
+                    }
+
+                    const removeItemButton = event.target.closest('.remove-item-btn');
+                    if (removeItemButton) {
+                        removeItemButton.closest('.flex').remove();
+                        return;
+                    }
+
+                    const removePackageButton = event.target.closest('.remove-package-btn');
+                    if (removePackageButton) {
+                        removePackageButton.closest('.package-card').remove();
+                        renumberPackages();
+                    }
+                });
+            });
+        </script>
+    @endif
+
+    @if($activeTab === 'schedules')
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                const repeater = document.getElementById('schedules-repeater');
+                const addBtn = document.getElementById('add-schedule-btn');
+                if (!repeater || !addBtn) return;
+
+                const renumber = () => {
+                    repeater.querySelectorAll('.schedule-row').forEach((row, index) => {
+                        row.dataset.scheduleIndex = index;
+                        row.querySelector('.schedule-seq').textContent = index + 1;
+                        row.querySelectorAll('input, select').forEach((field) => {
+                            if (!field.name) return;
+                            field.name = field.name.replace(/schedules\[\d+]/, `schedules[${index}]`);
+                        });
+                    });
+                };
+
+                addBtn.addEventListener('click', function () {
+                    const index = repeater.querySelectorAll('.schedule-row').length;
+                    repeater.insertAdjacentHTML('beforeend', `
+                        <div class="schedule-row bg-white border rounded-xl p-3 space-y-2" data-schedule-index="${index}">
+                            <div class="flex justify-between">
+                                <h3 class="font-semibold text-sm text-gray-700">Schedule #<span class="schedule-seq">${index + 1}</span></h3>
+                                <button type="button" class="remove-schedule-btn px-2 py-1 border rounded text-red-600">Remove</button>
+                            </div>
+                            <input type="hidden" name="schedules[${index}][id]" value="">
+                            <div class="grid md:grid-cols-6 gap-2">
+                                <input type="date" name="schedules[${index}][start_date]" class="border rounded p-2" required>
+                                <input type="date" name="schedules[${index}][end_date]" class="border rounded p-2" required>
+                                <input type="date" name="schedules[${index}][booking_deadline]" class="border rounded p-2">
+                                <input type="number" name="schedules[${index}][available_seats]" class="border rounded p-2" placeholder="Seats">
+                                <input type="number" step="0.01" name="schedules[${index}][price_modifier]" class="border rounded p-2" placeholder="Price modifier">
+                                <select name="schedules[${index}][status]" class="border rounded p-2">
+                                    <option value="available">Available</option>
+                                    <option value="full">Full</option>
+                                    <option value="cancelled">Cancelled</option>
+                                </select>
+                            </div>
+                        </div>
+                    `);
+                });
+
+                repeater.addEventListener('click', function (event) {
+                    const removeBtn = event.target.closest('.remove-schedule-btn');
+                    if (!removeBtn) return;
+                    removeBtn.closest('.schedule-row').remove();
+                    renumber();
+                });
+            });
+        </script>
+    @endif
+
+    @if($activeTab === 'images')
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                const repeater = document.getElementById('images-repeater');
+                const addBtn = document.getElementById('add-image-btn');
+                if (!repeater || !addBtn) return;
+
+                const emptyNote = document.getElementById('images-empty-note');
+
+                const renumber = () => {
+                    repeater.querySelectorAll('.image-row').forEach((row, index) => {
+                        row.dataset.imageIndex = index;
+                        row.querySelectorAll('input').forEach((field) => {
+                            if (!field.name) return;
+                            field.name = field.name.replace(/images\[\d+]/, `images[${index}]`);
+                        });
+                    });
+                };
+
+                addBtn.addEventListener('click', function () {
+                    if (emptyNote) emptyNote.remove();
+                    const index = repeater.querySelectorAll('.image-row').length;
+                    repeater.insertAdjacentHTML('beforeend', `
+                        <div class="image-row flex items-center gap-2" data-image-index="${index}">
+                            <input type="hidden" name="images[${index}][id]" value="">
+                            <input name="images[${index}][image_path]" class="w-full border rounded p-2" placeholder="Other image path">
+                            <button type="button" class="remove-image-btn px-3 py-2 border rounded text-red-600">Remove</button>
+                        </div>
+                    `);
+                });
+
+                repeater.addEventListener('click', function (event) {
+                    const removeBtn = event.target.closest('.remove-image-btn');
+                    if (!removeBtn) return;
+                    removeBtn.closest('.image-row').remove();
+                    renumber();
                 });
             });
         </script>


### PR DESCRIPTION
### Motivation
- Convert the AI trip completion forms to a repeater pattern so admins can add/remove multiple packages, schedule rows, and gallery images inline. 
- Change package inputs (`includes`, `excludes`, `highlights`) from single large textareas into repeatable fields for better structure and UX. 
- Keep a dedicated cover image field while allowing an arbitrary number of gallery images.

### Description
- Replaced the Packages tab HTML with a repeater-based UI in `resources/views/trips/ai/complete.blade.php`, adding per-package cards, repeatable `includes`/`excludes`/`highlights` lists, and an `+ Add package` action. 
- Replaced the Schedules and Images tab HTML with repeater-based UIs in the same blade file and added JS-driven add/remove/renumber logic for schedules and gallery images. 
- Added client-side JavaScript for packages, schedules, and images to handle dynamic row creation, removal, and input name renumbering so the server receives consistent array payloads. 
- Updated `AiTripController::savePackages` (in `app/Http/Controllers/AiTripController.php`) to accept repeater-style arrays for `packages.*.includes`, `packages.*.excludes`, and `packages.*.highlights`, and added `normalizeRepeaterInput` to normalize either array or newline-separated string input before persisting includes/excludes/highlights. 

### Testing
- Ran `php -l app/Http/Controllers/AiTripController.php` and confirmed there are no PHP syntax errors. 
- Attempted `php artisan test --filter=AiTripControllerTest` but the test run could not execute in this environment because `vendor/autoload.php` is missing, so automated test suite could not be run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d53f28d0c8832fb19634875fcb160b)