### PR TITLE
Add hotel fields to AI packages and support image file uploads in trip completion

### DIFF
--- a/app/Http/Controllers/AiTripController.php
+++ b/app/Http/Controllers/AiTripController.php
@@ -19,6 +19,7 @@ use App\Models\TripSchedule;
 use App\Services\GroqTripPlannerService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 class AiTripController extends Controller
@@ -383,30 +384,44 @@ class AiTripController extends Controller
     {
         $validated = $request->validate([
             'cover_image_path' => 'nullable|string|max:255',
+            'cover_image_file' => 'nullable|image|mimes:jpg,jpeg,png,webp|max:5120',
             'images' => 'nullable|array',
             'images.*.id' => 'nullable|exists:trip_images,id',
             'images.*.image_path' => 'nullable|string|max:255',
+            'images.*.existing_path' => 'nullable|string|max:255',
+            'images.*.image_file' => 'nullable|image|mimes:jpg,jpeg,png,webp|max:5120',
         ]);
 
-        DB::transaction(function () use ($trip, $validated) {
+        DB::transaction(function () use ($trip, $validated, $request) {
             $trip->images()->delete();
 
-            if (! empty($validated['cover_image_path'])) {
+            $coverImagePath = $validated['cover_image_path'] ?? null;
+            if ($request->hasFile('cover_image_file')) {
+                $coverImagePath = '/storage/' . Storage::disk('public')->put('trips', $request->file('cover_image_file'));
+            }
+
+            if (! empty($coverImagePath)) {
                 TripImage::create([
                     'trip_id' => $trip->id,
-                    'image_path' => $validated['cover_image_path'],
+                    'image_path' => $coverImagePath,
                     'is_cover' => true,
                 ]);
             }
 
-            foreach (($validated['images'] ?? []) as $imagePayload) {
-                if (blank($imagePayload['image_path'] ?? null)) {
+            foreach (($validated['images'] ?? []) as $index => $imagePayload) {
+                $imagePath = $imagePayload['existing_path'] ?? ($imagePayload['image_path'] ?? null);
+
+                if ($request->hasFile("images.$index.image_file")) {
+                    $imagePath = '/storage/' . Storage::disk('public')->put('trips', $request->file("images.$index.image_file"));
+                }
+
+                if (blank($imagePath)) {
                     continue;
                 }
 
                 TripImage::create([
                     'trip_id' => $trip->id,
-                    'image_path' => $imagePayload['image_path'],
+                    'image_path' => $imagePath,
                     'is_cover' => false,
                 ]);
             }

--- a/resources/views/trips/ai/complete.blade.php
+++ b/resources/views/trips/ai/complete.blade.php
@@ -204,6 +204,16 @@
                             })->values()->all(),
                         ];
                     })->values()->all());
+
+                    $canonicalHotels = $trip->days
+                        ->whereNotNull('hotel_id')
+                        ->map(fn ($day) => [
+                            'hotel_id' => $day->hotel_id,
+                            'hotel_name' => optional($day->hotel)->name,
+                        ])
+                        ->unique('hotel_id')
+                        ->values()
+                        ->all();
                 @endphp
 
                 <div id="packages-repeater" class="space-y-4">
@@ -337,11 +347,13 @@
         @endif
 
         @if($activeTab === 'images')
-            <form method="POST" action="{{ route('trip.complete.images', $trip->id) }}" class="space-y-3 bg-white border rounded-xl p-4">
+            <form method="POST" action="{{ route('trip.complete.images', $trip->id) }}" enctype="multipart/form-data" class="space-y-3 bg-white border rounded-xl p-4">
                 @csrf
                 <div>
                     <label class="block text-sm">Cover image path</label>
                     <input name="cover_image_path" value="{{ old('cover_image_path', optional($trip->images->firstWhere('is_cover', true))->image_path) }}" class="w-full border rounded p-2" placeholder="/storage/trips/cover.jpg">
+                    <label class="block text-sm mt-2">Or choose cover image</label>
+                    <input type="file" name="cover_image_file" accept="image/*" class="w-full border rounded p-2">
                 </div>
 
                 @php
@@ -358,7 +370,9 @@
                     @forelse($otherImages as $index => $image)
                         <div class="image-row flex items-center gap-2" data-image-index="{{ $index }}">
                             <input type="hidden" name="images[{{ $index }}][id]" value="{{ $image['id'] ?? '' }}">
+                            <input type="hidden" name="images[{{ $index }}][existing_path]" value="{{ $image['image_path'] ?? '' }}">
                             <input name="images[{{ $index }}][image_path]" value="{{ $image['image_path'] ?? '' }}" class="w-full border rounded p-2" placeholder="Other image path">
+                            <input type="file" name="images[{{ $index }}][image_file]" accept="image/*" class="w-full border rounded p-2">
                             <button type="button" class="remove-image-btn px-3 py-2 border rounded text-red-600">Remove</button>
                         </div>
                     @empty
@@ -452,6 +466,7 @@
                 const repeater = document.getElementById('packages-repeater');
                 const addPackageBtn = document.getElementById('add-package-btn');
                 if (!repeater || !addPackageBtn) return;
+                const canonicalHotels = @json($canonicalHotels);
 
                 const renumberPackages = () => {
                     repeater.querySelectorAll('.package-card').forEach((card, packageIndex) => {
@@ -475,6 +490,17 @@
 
                 const packageTemplate = () => {
                     const nextIndex = repeater.querySelectorAll('.package-card').length;
+                    const hotelsRows = canonicalHotels.map((hotel, hotelIndex) => `
+                        <div class="grid md:grid-cols-4 gap-2 p-2 border rounded">
+                            <input type="hidden" name="packages[${nextIndex}][hotels][${hotelIndex}][hotel_id]" value="${hotel.hotel_id}">
+                            <input value="${hotel.hotel_name ?? ''}" class="border rounded p-2 bg-gray-100" readonly>
+                            <input name="packages[${nextIndex}][hotels][${hotelIndex}][room_type]" class="border rounded p-2" placeholder="Room type">
+                            <input name="packages[${nextIndex}][hotels][${hotelIndex}][meal_plan]" class="border rounded p-2" placeholder="Meal plan">
+                            <input name="packages[${nextIndex}][hotels][${hotelIndex}][amenities]" class="border rounded p-2" placeholder="Amenities comma separated">
+                            <textarea name="packages[${nextIndex}][hotels][${hotelIndex}][notes]" class="border rounded p-2 md:col-span-4" rows="2" placeholder="Notes / package differentiation"></textarea>
+                        </div>
+                    `).join('');
+
                     return `
                         <div class="package-card bg-white border rounded-xl p-4 space-y-3" data-package-index="${nextIndex}">
                             <div class="flex justify-between items-start gap-3">
@@ -508,6 +534,9 @@
                                     </div>
                                     <div class="items-list space-y-2" data-list-type="highlights"></div>
                                 </div>
+                            </div>
+                            <div class="space-y-2">
+                                ${hotelsRows || '<p class="text-sm text-gray-500">No hotels found from itinerary days yet.</p>'}
                             </div>
                         </div>
                     `;
@@ -621,7 +650,9 @@
                     repeater.insertAdjacentHTML('beforeend', `
                         <div class="image-row flex items-center gap-2" data-image-index="${index}">
                             <input type="hidden" name="images[${index}][id]" value="">
+                            <input type="hidden" name="images[${index}][existing_path]" value="">
                             <input name="images[${index}][image_path]" class="w-full border rounded p-2" placeholder="Other image path">
+                            <input type="file" name="images[${index}][image_file]" accept="image/*" class="w-full border rounded p-2">
                             <button type="button" class="remove-image-btn px-3 py-2 border rounded text-red-600">Remove</button>
                         </div>
                     `);


### PR DESCRIPTION
### Motivation
- Fix the AI trip completion UI where newly added packages only showed `name`, `price`, `includes`, `excludes`, and `highlights` but not per-hotel fields (room type, meal plan, amenities, notes). 
- Allow editors to pick images using a file picker instead of requiring typed storage paths when completing AI-generated trips. 
- Preserve backward compatibility for existing image-path entries while enabling uploaded-file handling.

### Description
- Render a canonical list of itinerary hotels in the packages view and include hotel rows (hidden `hotel_id`, hotel name, `room_type`, `meal_plan`, `amenities`, `notes`) for newly added packages in the JS `packageTemplate` to ensure new packages include hotel-specific fields. 
- Add server-side support for uploaded cover and gallery images by adding validation rules for `cover_image_file` and `images.*.image_file`, importing `Storage`, and persisting files to the public disk under `trips/` while storing `/storage/...` paths. 
- Keep and submit existing typed paths by adding an `existing_path` hidden field and falling back to it when no file is uploaded so old workflows continue to work. 
- Update the images form to `enctype=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d546a672e8832f841331273087a330)