### PR TITLE
Add Guides & Drivers staffing workflow and Trip state pattern

### DIFF
--- a/app/Domain/Trip/Factory/TripStateFactory.php
+++ b/app/Domain/Trip/Factory/TripStateFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Domain\Trip\Factory;
+
+use App\Domain\Trip\States\DraftTripState;
+use App\Domain\Trip\States\PublishedTripState;
+use App\Domain\Trip\States\ReadyForAssignmentTripState;
+use App\Domain\Trip\States\ReadyForStaffingTripState;
+use App\Domain\Trip\States\StaffedTripState;
+use App\Domain\Trip\States\StaffingInProgressTripState;
+use App\Domain\Trip\States\TripState;
+use InvalidArgumentException;
+
+class TripStateFactory
+{
+    public static function make(string $status): TripState
+    {
+        return match ($status) {
+            'draft' => new DraftTripState(),
+            'ready_for_assignment' => new ReadyForAssignmentTripState(),
+            'ready_for_staffing' => new ReadyForStaffingTripState(),
+            'staffing_in_progress' => new StaffingInProgressTripState(),
+            'staffed' => new StaffedTripState(),
+            'published' => new PublishedTripState(),
+            default => throw new InvalidArgumentException("Unsupported trip status [{$status}]."),
+        };
+    }
+}

--- a/app/Domain/Trip/States/DraftTripState.php
+++ b/app/Domain/Trip/States/DraftTripState.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Domain\Trip\States;
+
+class DraftTripState extends TripState
+{
+    public function name(): string
+    {
+        return 'draft';
+    }
+
+    protected function allowedTransitions(): array
+    {
+        return ['ready_for_assignment'];
+    }
+}

--- a/app/Domain/Trip/States/PublishedTripState.php
+++ b/app/Domain/Trip/States/PublishedTripState.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Domain\Trip\States;
+
+class PublishedTripState extends TripState
+{
+    public function name(): string
+    {
+        return 'published';
+    }
+
+    protected function allowedTransitions(): array
+    {
+        return [];
+    }
+}

--- a/app/Domain/Trip/States/ReadyForAssignmentTripState.php
+++ b/app/Domain/Trip/States/ReadyForAssignmentTripState.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Domain\Trip\States;
+
+class ReadyForAssignmentTripState extends TripState
+{
+    public function name(): string
+    {
+        return 'ready_for_assignment';
+    }
+
+    protected function allowedTransitions(): array
+    {
+        return ['ready_for_staffing'];
+    }
+}

--- a/app/Domain/Trip/States/ReadyForStaffingTripState.php
+++ b/app/Domain/Trip/States/ReadyForStaffingTripState.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Domain\Trip\States;
+
+class ReadyForStaffingTripState extends TripState
+{
+    public function name(): string
+    {
+        return 'ready_for_staffing';
+    }
+
+    protected function allowedTransitions(): array
+    {
+        return ['staffing_in_progress'];
+    }
+}

--- a/app/Domain/Trip/States/StaffedTripState.php
+++ b/app/Domain/Trip/States/StaffedTripState.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Domain\Trip\States;
+
+class StaffedTripState extends TripState
+{
+    public function name(): string
+    {
+        return 'staffed';
+    }
+
+    protected function allowedTransitions(): array
+    {
+        return ['published'];
+    }
+}

--- a/app/Domain/Trip/States/StaffingInProgressTripState.php
+++ b/app/Domain/Trip/States/StaffingInProgressTripState.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Domain\Trip\States;
+
+class StaffingInProgressTripState extends TripState
+{
+    public function name(): string
+    {
+        return 'staffing_in_progress';
+    }
+
+    protected function allowedTransitions(): array
+    {
+        return ['staffed'];
+    }
+}

--- a/app/Domain/Trip/States/TripState.php
+++ b/app/Domain/Trip/States/TripState.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Domain\Trip\States;
+
+abstract class TripState
+{
+    abstract public function name(): string;
+
+    public function canTransitionTo(string $nextStatus): bool
+    {
+        return in_array($nextStatus, $this->allowedTransitions(), true);
+    }
+
+    /**
+     * @return string[]
+     */
+    abstract protected function allowedTransitions(): array;
+}
+

--- a/app/Http/Controllers/AiTripCompletionController.php
+++ b/app/Http/Controllers/AiTripCompletionController.php
@@ -3,7 +3,9 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\AiTripBasicsRequest;
+use App\Http\Requests\AiTripDriversRequest;
 use App\Http\Requests\AiTripDaysActivitiesRequest;
+use App\Http\Requests\AiTripGuidesRequest;
 use App\Http\Requests\AiTripImagesRequest;
 use App\Http\Requests\AiTripPackagesRequest;
 use App\Http\Requests\AiTripSchedulesRequest;
@@ -59,5 +61,21 @@ class AiTripCompletionController extends Controller
 
         return redirect()->route('trip.complete.edit', ['trip' => $trip, 'tab' => 'images'])
             ->with('success', 'Images saved successfully.');
+    }
+
+    public function saveGuides(AiTripGuidesRequest $request, Trip $trip)
+    {
+        $this->tripService->saveGuides($trip, $request->validated());
+
+        return redirect()->route('trip.complete.edit', ['trip' => $trip, 'tab' => 'guides'])
+            ->with('success', 'Guide requirements saved successfully.');
+    }
+
+    public function saveDrivers(AiTripDriversRequest $request, Trip $trip)
+    {
+        $this->tripService->saveDrivers($trip, $request->validated());
+
+        return redirect()->route('trip.complete.edit', ['trip' => $trip, 'tab' => 'drivers'])
+            ->with('success', 'Driver requirements saved and trip is ready for assignment.');
     }
 }

--- a/app/Http/Controllers/AiTripController.php
+++ b/app/Http/Controllers/AiTripController.php
@@ -6,6 +6,7 @@ use App\Enums\Category;
 use App\Models\Activity;
 use App\Models\Destination;
 use App\Models\Hotel;
+use App\Models\Specialization;
 use App\Models\Trip;
 
 class AiTripController extends Controller
@@ -45,7 +46,8 @@ class AiTripController extends Controller
         $destinations = Destination::query()->orderBy('name')->get(['id', 'name']);
         $activities = Activity::query()->orderBy('name')->get(['id', 'name']);
         $hotels = Hotel::query()->orderBy('name')->get(['id', 'name']);
+        $specializations = Specialization::query()->orderBy('name')->get(['id', 'name']);
 
-        return view('trips.ai.complete', compact('trip', 'activeTab', 'destinations', 'activities', 'hotels'));
+        return view('trips.ai.complete', compact('trip', 'activeTab', 'destinations', 'activities', 'hotels', 'specializations'));
     }
 }

--- a/app/Http/Requests/AiTripDriversRequest.php
+++ b/app/Http/Requests/AiTripDriversRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AiTripDriversRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'vehicle_type' => ['nullable', 'string', 'max:100', 'required_without:vehicle_capacity'],
+            'vehicle_capacity' => ['nullable', 'integer', 'min:1', 'required_without:vehicle_type'],
+            'trip_type' => ['required', 'string', 'in:single_day,multi_day'],
+            'road_type' => ['required', 'string', 'in:city,mountain,off_road'],
+        ];
+    }
+}

--- a/app/Http/Requests/AiTripGuidesRequest.php
+++ b/app/Http/Requests/AiTripGuidesRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AiTripGuidesRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'guide_specialization_ids' => ['nullable', 'array'],
+            'guide_specialization_ids.*' => ['required', 'integer', 'exists:specializations,id'],
+            'requires_tour_leader' => ['nullable', 'boolean'],
+        ];
+    }
+}

--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -21,11 +21,22 @@ class Trip extends Model
         'is_ai_generated',
         'ai_prompt',
         'status',
+        'guide_specialization_ids',
+        'requires_tour_leader',
+        'driver_vehicle_type',
+        'driver_vehicle_capacity',
+        'driver_trip_type',
+        'driver_road_type',
     ];
 
     protected $hidden = [
         'created_at',
         'updated_at'
+    ];
+
+    protected $casts = [
+        'guide_specialization_ids' => 'array',
+        'requires_tour_leader' => 'boolean',
     ];
 
    public function packages()

--- a/app/Services/AiTrip/TripService.php
+++ b/app/Services/AiTrip/TripService.php
@@ -13,6 +13,7 @@ use App\Models\TripPackage;
 use App\Models\TripPackageHotel;
 use App\Models\TripSchedule;
 use App\Services\GroqTripPlannerService;
+use App\Services\Trip\TripStateManager;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
@@ -20,7 +21,10 @@ use Illuminate\Support\Str;
 
 class TripService
 {
-    public function __construct(protected GroqTripPlannerService $groqService)
+    public function __construct(
+        protected GroqTripPlannerService $groqService,
+        protected TripStateManager $tripStateManager
+    )
     {
     }
 
@@ -235,6 +239,34 @@ class TripService
                     'is_cover' => false,
                 ]);
             }
+        });
+    }
+
+    public function saveGuides(Trip $trip, array $payload): void
+    {
+        $specializationIds = collect($payload['guide_specialization_ids'] ?? [])
+            ->map(fn ($id) => (int) $id)
+            ->unique()
+            ->values()
+            ->all();
+
+        $trip->update([
+            'guide_specialization_ids' => $specializationIds,
+            'requires_tour_leader' => (bool) ($payload['requires_tour_leader'] ?? true),
+        ]);
+    }
+
+    public function saveDrivers(Trip $trip, array $payload): void
+    {
+        DB::transaction(function () use ($trip, $payload) {
+            $trip->update([
+                'driver_vehicle_type' => $payload['vehicle_type'] ?? null,
+                'driver_vehicle_capacity' => $payload['vehicle_capacity'] ?? null,
+                'driver_trip_type' => $payload['trip_type'],
+                'driver_road_type' => $payload['road_type'],
+            ]);
+
+            $this->tripStateManager->transition($trip, 'ready_for_assignment');
         });
     }
 

--- a/app/Services/Trip/TripStateManager.php
+++ b/app/Services/Trip/TripStateManager.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Services\Trip;
+
+use App\Domain\Trip\Factory\TripStateFactory;
+use App\Models\Trip;
+use LogicException;
+
+class TripStateManager
+{
+    public function transition(Trip $trip, string $nextStatus): Trip
+    {
+        if ($trip->status === $nextStatus) {
+            return $trip->refresh();
+        }
+
+        $current = TripStateFactory::make($trip->status);
+
+        if (! $current->canTransitionTo($nextStatus)) {
+            throw new LogicException("Cannot transition trip from {$trip->status} to {$nextStatus}.");
+        }
+
+        $trip->update(['status' => $nextStatus]);
+
+        return $trip->refresh();
+    }
+}

--- a/database/migrations/2026_04_09_120000_add_staffing_requirements_to_trips_table.php
+++ b/database/migrations/2026_04_09_120000_add_staffing_requirements_to_trips_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->json('guide_specialization_ids')->nullable()->after('status');
+            $table->boolean('requires_tour_leader')->default(true)->after('guide_specialization_ids');
+            $table->string('driver_vehicle_type')->nullable()->after('requires_tour_leader');
+            $table->unsignedInteger('driver_vehicle_capacity')->nullable()->after('driver_vehicle_type');
+            $table->string('driver_trip_type')->nullable()->after('driver_vehicle_capacity');
+            $table->string('driver_road_type')->nullable()->after('driver_trip_type');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->dropColumn([
+                'guide_specialization_ids',
+                'requires_tour_leader',
+                'driver_vehicle_type',
+                'driver_vehicle_capacity',
+                'driver_trip_type',
+                'driver_road_type',
+            ]);
+        });
+    }
+};

--- a/resources/views/trips/ai/complete.blade.php
+++ b/resources/views/trips/ai/complete.blade.php
@@ -28,7 +28,7 @@
                 'schedules' => 'Schedules',
                 'images' => 'Images',
                 'guides' => 'Guides',
-                'transports' => 'Transport',
+                'drivers' => 'Drivers',
             ];
         @endphp
 
@@ -387,11 +387,101 @@
         @endif
 
         @if($activeTab === 'guides')
-            <div class="bg-white border rounded-xl p-6 text-gray-600">Guides form is intentionally left empty for now.</div>
+            @php
+                $selectedSpecializationIds = collect(old('guide_specialization_ids', $trip->guide_specialization_ids ?? []))
+                    ->map(fn ($id) => (int) $id)
+                    ->all();
+                $requiresTourLeader = (bool) old('requires_tour_leader', $trip->requires_tour_leader ?? true);
+            @endphp
+            <form method="POST" action="{{ route('trip.complete.guides', $trip->id) }}" class="bg-white border rounded-xl p-6 space-y-5">
+                @csrf
+                <div>
+                    <h3 class="font-semibold text-lg mb-2">Guide requirements</h3>
+                    <p class="text-sm text-gray-600">Select the required guide specializations for this trip. This save will not change trip status.</p>
+                </div>
+
+                <div class="space-y-2">
+                    <label class="block text-sm font-medium">Specializations</label>
+                    <div class="grid md:grid-cols-3 gap-3">
+                        @foreach($specializations as $specialization)
+                            <label class="flex items-center gap-2 p-3 border rounded">
+                                <input
+                                    type="checkbox"
+                                    name="guide_specialization_ids[]"
+                                    value="{{ $specialization->id }}"
+                                    @checked(in_array($specialization->id, $selectedSpecializationIds, true))
+                                >
+                                <span>{{ $specialization->name }}</span>
+                            </label>
+                        @endforeach
+                    </div>
+                </div>
+
+                <div class="p-4 border rounded bg-gray-50">
+                    <label class="flex items-center gap-2">
+                        <input type="hidden" name="requires_tour_leader" value="0">
+                        <input type="checkbox" name="requires_tour_leader" value="1" @checked($requiresTourLeader)>
+                        <span class="font-medium">Tour Leader required</span>
+                    </label>
+                    <p class="text-xs text-gray-500 mt-1">Default is required. You can turn this off if not needed.</p>
+                </div>
+
+                <button class="px-5 py-2 bg-blue-600 text-white rounded">Save Guides & Continue</button>
+            </form>
         @endif
 
-        @if($activeTab === 'transports')
-            <div class="bg-white border rounded-xl p-6 text-gray-600">Transports form is intentionally left empty for now.</div>
+        @if($activeTab === 'drivers')
+            <form method="POST" action="{{ route('trip.complete.drivers', $trip->id) }}" class="bg-white border rounded-xl p-6 space-y-5">
+                @csrf
+                <div>
+                    <h3 class="font-semibold text-lg mb-2">Driver requirements (final step)</h3>
+                    <p class="text-sm text-gray-600">Saving this step moves trip status from Draft to Ready for Assignment.</p>
+                </div>
+
+                <div class="grid md:grid-cols-2 gap-4">
+                    <div>
+                        <label class="block text-sm font-medium">Vehicle type</label>
+                        <input
+                            name="vehicle_type"
+                            value="{{ old('vehicle_type', $trip->driver_vehicle_type) }}"
+                            class="w-full border rounded p-2"
+                            placeholder="SUV, Van, Bus..."
+                        >
+                        <p class="text-xs text-gray-500 mt-1">Provide vehicle type or fill capacity.</p>
+                    </div>
+
+                    <div>
+                        <label class="block text-sm font-medium">Vehicle capacity</label>
+                        <input
+                            type="number"
+                            min="1"
+                            name="vehicle_capacity"
+                            value="{{ old('vehicle_capacity', $trip->driver_vehicle_capacity) }}"
+                            class="w-full border rounded p-2"
+                            placeholder="Seats count"
+                        >
+                    </div>
+
+                    <div>
+                        <label class="block text-sm font-medium">Trip type</label>
+                        <select name="trip_type" class="w-full border rounded p-2" required>
+                            <option value="single_day" @selected(old('trip_type', $trip->driver_trip_type) === 'single_day')>Single-day</option>
+                            <option value="multi_day" @selected(old('trip_type', $trip->driver_trip_type) === 'multi_day')>Multi-day</option>
+                        </select>
+                    </div>
+
+                    <div>
+                        <label class="block text-sm font-medium">Road type</label>
+                        <select name="road_type" class="w-full border rounded p-2" required>
+                            <option value="city" @selected(old('road_type', $trip->driver_road_type) === 'city')>City</option>
+                            <option value="mountain" @selected(old('road_type', $trip->driver_road_type) === 'mountain')>Mountain</option>
+                            <option value="off_road" @selected(old('road_type', $trip->driver_road_type) === 'off_road')>Off-road</option>
+                        </select>
+                    </div>
+                </div>
+
+                <button class="px-5 py-2 bg-blue-600 text-white rounded">Save Drivers (Finalize Staffing Requirements)</button>
+            </form>
         @endif
     </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -243,6 +243,8 @@ Route::post('/trips/{trip}/complete/days', [AiTripCompletionController::class, '
 Route::post('/trips/{trip}/complete/packages', [AiTripCompletionController::class, 'savePackages'])->name('trip.complete.packages');
 Route::post('/trips/{trip}/complete/schedules', [AiTripCompletionController::class, 'saveSchedules'])->name('trip.complete.schedules');
 Route::post('/trips/{trip}/complete/images', [AiTripCompletionController::class, 'saveImages'])->name('trip.complete.images');
+Route::post('/trips/{trip}/complete/guides', [AiTripCompletionController::class, 'saveGuides'])->name('trip.complete.guides');
+Route::post('/trips/{trip}/complete/drivers', [AiTripCompletionController::class, 'saveDrivers'])->name('trip.complete.drivers');
 
 //Activities routes
 Route::get('/activities',[ActivityController::class,'index'])->name('activities.index');
@@ -279,7 +281,6 @@ Route::middleware(['auth','check.driver.status']) ->prefix('driver') ->group(fun
 
 
 require __DIR__.'/auth.php';
-
 
 
 


### PR DESCRIPTION
### Motivation
- Implement the Complete AI Trip staffing workflow so admins can record guide specializations and driver requirements as part of the trip completion flow.
- Follow the existing Transport Reservation design by introducing a clean State pattern for Trip lifecycle management.
- Ensure intermediate Guide-step saves do not trigger staffing or status transitions while the final Driver-step save marks the trip ready for assignment.

### Description
- Added a Trip State pattern with state classes and a `TripStateFactory` and `TripStateManager` to enforce allowed status transitions (`draft`, `ready_for_assignment`, `ready_for_staffing`, `staffing_in_progress`, `staffed`, `published`).
- Persisted staffing requirement fields on `trips` via a migration and extended the `Trip` model `fillable`/`casts` to include `guide_specialization_ids`, `requires_tour_leader`, and driver requirement fields.
- Added request validators `AiTripGuidesRequest` and `AiTripDriversRequest`, controller actions `saveGuides()` and `saveDrivers()` in `AiTripCompletionController`, new `TripService` methods `saveGuides()` and `saveDrivers()`, and routes for the new endpoints.
- Updated the AI trip completion UI (`trips.ai.complete`) to include a Guides tab (select specializations + tour leader toggle) and a Drivers tab (vehicle type/capacity, trip type, road type) where the final Drivers save transitions the trip to `ready_for_assignment` while Guides save only persists requirements.

### Testing
- Ran PHP syntax checks with `php -l` for the modified/new files and they all passed (checked `AiTripCompletionController`, `AiTripController`, `TripService`, `TripStateManager`, `TripStateFactory`, `AiTripGuidesRequest`, `AiTripDriversRequest`, `Trip` model and the new migration).
- Attempted to run `php artisan test --filter=TripTest` but the test run failed in this environment due to missing project dependencies (`vendor/autoload.php`), not due to the changes themselves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7a3c3f4a8832f9b1aae6d768176a0)