### PR TITLE
Async AI Trip staffing workflow for Guides and Drivers (jobs, chain, ranking)

### DIFF
--- a/app/Domain/Trip/States/ReadyForAssignmentTripState.php
+++ b/app/Domain/Trip/States/ReadyForAssignmentTripState.php
@@ -11,6 +11,6 @@ class ReadyForAssignmentTripState extends TripState
 
     protected function allowedTransitions(): array
     {
-        return ['ready_for_staffing'];
+        return ['ready_for_staffing', 'staffing_in_progress'];
     }
 }

--- a/app/Domain/Trip/States/StaffingInProgressTripState.php
+++ b/app/Domain/Trip/States/StaffingInProgressTripState.php
@@ -11,6 +11,6 @@ class StaffingInProgressTripState extends TripState
 
     protected function allowedTransitions(): array
     {
-        return ['staffed'];
+        return ['staffed', 'draft'];
     }
 }

--- a/app/Domain/TripStaffing/DriverChain/SendToNextTripDriverHandler.php
+++ b/app/Domain/TripStaffing/DriverChain/SendToNextTripDriverHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Domain\TripStaffing\DriverChain;
+
+use App\Jobs\TripStaffing\SendDriverRequestJob;
+use App\Models\Trip;
+
+class SendToNextTripDriverHandler extends TripDriverRequestHandler
+{
+    protected function process(Trip $trip, array $rankedDriverIds, int $index): bool
+    {
+        if (! isset($rankedDriverIds[$index])) {
+            return false;
+        }
+
+        SendDriverRequestJob::dispatchSync($trip->id, $rankedDriverIds[$index], $rankedDriverIds, $index);
+
+        return true;
+    }
+}

--- a/app/Domain/TripStaffing/DriverChain/TripDriverRequestHandler.php
+++ b/app/Domain/TripStaffing/DriverChain/TripDriverRequestHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Domain\TripStaffing\DriverChain;
+
+use App\Models\Trip;
+
+abstract class TripDriverRequestHandler
+{
+    protected ?TripDriverRequestHandler $next = null;
+
+    public function setNext(TripDriverRequestHandler $next): TripDriverRequestHandler
+    {
+        $this->next = $next;
+
+        return $next;
+    }
+
+    public function handle(Trip $trip, array $rankedDriverIds, int $index = 0): void
+    {
+        if (! $this->process($trip, $rankedDriverIds, $index) && $this->next) {
+            $this->next->handle($trip, $rankedDriverIds, $index + 1);
+        }
+    }
+
+    abstract protected function process(Trip $trip, array $rankedDriverIds, int $index): bool;
+}

--- a/app/Domain/TripStaffing/GuideChain/GuideRequestHandler.php
+++ b/app/Domain/TripStaffing/GuideChain/GuideRequestHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Domain\TripStaffing\GuideChain;
+
+use App\Models\Trip;
+
+abstract class GuideRequestHandler
+{
+    protected ?GuideRequestHandler $next = null;
+
+    public function setNext(GuideRequestHandler $next): GuideRequestHandler
+    {
+        $this->next = $next;
+
+        return $next;
+    }
+
+    public function handle(Trip $trip, array $rankedGuideIds, int $index = 0): void
+    {
+        if (! $this->process($trip, $rankedGuideIds, $index) && $this->next) {
+            $this->next->handle($trip, $rankedGuideIds, $index + 1);
+        }
+    }
+
+    abstract protected function process(Trip $trip, array $rankedGuideIds, int $index): bool;
+}

--- a/app/Domain/TripStaffing/GuideChain/SendToNextGuideHandler.php
+++ b/app/Domain/TripStaffing/GuideChain/SendToNextGuideHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Domain\TripStaffing\GuideChain;
+
+use App\Jobs\TripStaffing\SendGuideRequestJob;
+use App\Models\Trip;
+
+class SendToNextGuideHandler extends GuideRequestHandler
+{
+    protected function process(Trip $trip, array $rankedGuideIds, int $index): bool
+    {
+        if (! isset($rankedGuideIds[$index])) {
+            return false;
+        }
+
+        SendGuideRequestJob::dispatchSync($trip->id, $rankedGuideIds[$index], $rankedGuideIds, $index);
+
+        return true;
+    }
+}

--- a/app/Domain/TripStaffing/Ranking/GuideRankingStrategy.php
+++ b/app/Domain/TripStaffing/Ranking/GuideRankingStrategy.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Domain\TripStaffing\Ranking;
+
+use Illuminate\Support\Collection;
+
+interface GuideRankingStrategy
+{
+    public function rank(Collection $guides): Collection;
+}

--- a/app/Domain/TripStaffing/Ranking/LastTripAndTripsCountGuideStrategy.php
+++ b/app/Domain/TripStaffing/Ranking/LastTripAndTripsCountGuideStrategy.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Domain\TripStaffing\Ranking;
+
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+class LastTripAndTripsCountGuideStrategy implements GuideRankingStrategy
+{
+    public function rank(Collection $guides): Collection
+    {
+        return $guides->sortBy(function ($guide) {
+            $lastTripAt = $guide->last_trip_at;
+
+            if (! $lastTripAt) {
+                $lastTripTimestamp = now()->subYears(20)->timestamp;
+            } elseif ($lastTripAt instanceof \DateTimeInterface) {
+                $lastTripTimestamp = $lastTripAt->getTimestamp();
+            } else {
+                $lastTripTimestamp = Carbon::parse($lastTripAt)->timestamp;
+            }
+
+            return [
+                (int) ($guide->total_trips_count ?? 0),
+                $lastTripTimestamp,
+            ];
+        })->values();
+    }
+}

--- a/app/Http/Controllers/AiTripCompletionController.php
+++ b/app/Http/Controllers/AiTripCompletionController.php
@@ -76,6 +76,6 @@ class AiTripCompletionController extends Controller
         $this->tripService->saveDrivers($trip, $request->validated());
 
         return redirect()->route('trip.complete.edit', ['trip' => $trip, 'tab' => 'drivers'])
-            ->with('success', 'Driver requirements saved and trip is ready for assignment.');
+            ->with('success', 'Driver requirements saved. Staffing process started.');
     }
 }

--- a/app/Http/Controllers/Driver/TripDriverRequestResponseController.php
+++ b/app/Http/Controllers/Driver/TripDriverRequestResponseController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers\Driver;
+
+use App\Http\Controllers\Controller;
+use App\Jobs\TripStaffing\ProcessNextDriverInChainJob;
+use App\Models\DriverRequest;
+use App\Services\TripStaffing\TripStaffingCoordinator;
+use Illuminate\Http\RedirectResponse;
+
+class TripDriverRequestResponseController extends Controller
+{
+    public function accept(DriverRequest $driverRequest, TripStaffingCoordinator $coordinator): RedirectResponse
+    {
+        $driver = auth()->user()?->driver;
+
+        abort_unless($driver && $driverRequest->driver_id === $driver->id, 403);
+
+        if (! $coordinator->acceptDriverRequest($driverRequest)) {
+            return back()->withErrors('Driver request is no longer pending.');
+        }
+
+        return back()->with('success', 'Driver request accepted successfully.');
+    }
+
+    public function reject(DriverRequest $driverRequest, TripStaffingCoordinator $coordinator): RedirectResponse
+    {
+        $driver = auth()->user()?->driver;
+
+        abort_unless($driver && $driverRequest->driver_id === $driver->id, 403);
+        abort_unless($driverRequest->status === 'pending', 422, 'Request is no longer pending.');
+
+        $coordinator->rejectDriverRequest($driverRequest);
+
+        $rankedDriverIds = $driverRequest->trip->ranked_driver_ids ?? [];
+        $currentIndex = array_search($driver->id, $rankedDriverIds, true);
+
+        ProcessNextDriverInChainJob::dispatchSync(
+            $driverRequest->trip_id,
+            $rankedDriverIds,
+            $currentIndex === false ? ($driverRequest->chain_index + 1) : $currentIndex + 1
+        );
+
+        return back()->with('success', 'Driver request rejected.');
+    }
+}

--- a/app/Http/Controllers/Guide/GuideRequestResponseController.php
+++ b/app/Http/Controllers/Guide/GuideRequestResponseController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers\Guide;
+
+use App\Http\Controllers\Controller;
+use App\Jobs\TripStaffing\ProcessNextGuideInChainJob;
+use App\Models\GuideRequest;
+use App\Services\TripStaffing\TripStaffingCoordinator;
+use Illuminate\Http\RedirectResponse;
+
+class GuideRequestResponseController extends Controller
+{
+    public function accept(GuideRequest $guideRequest, TripStaffingCoordinator $coordinator): RedirectResponse
+    {
+        $guide = auth()->user()?->guide;
+
+        abort_unless($guide && $guideRequest->guide_id === $guide->id, 403);
+
+        if (! $coordinator->acceptGuideRequest($guideRequest)) {
+            return back()->withErrors('Guide request is no longer pending.');
+        }
+
+        return back()->with('success', 'Guide request accepted successfully.');
+    }
+
+    public function reject(GuideRequest $guideRequest, TripStaffingCoordinator $coordinator): RedirectResponse
+    {
+        $guide = auth()->user()?->guide;
+
+        abort_unless($guide && $guideRequest->guide_id === $guide->id, 403);
+        abort_unless($guideRequest->status === 'pending', 422, 'Request is no longer pending.');
+
+        $coordinator->rejectGuideRequest($guideRequest);
+
+        $rankedGuideIds = $guideRequest->trip->ranked_guide_ids ?? [];
+        $currentIndex = array_search($guide->id, $rankedGuideIds, true);
+
+        ProcessNextGuideInChainJob::dispatchSync(
+            $guideRequest->trip_id,
+            $rankedGuideIds,
+            $currentIndex === false ? ($guideRequest->chain_index + 1) : $currentIndex + 1
+        );
+
+        return back()->with('success', 'Guide request rejected.');
+    }
+}

--- a/app/Jobs/TripStaffing/CheckDriverRequestTimeoutJob.php
+++ b/app/Jobs/TripStaffing/CheckDriverRequestTimeoutJob.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Jobs\TripStaffing;
+
+use App\Models\DriverRequest;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class CheckDriverRequestTimeoutJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public int $driverRequestId, public array $rankedDriverIds, public int $currentIndex)
+    {
+    }
+
+    public function handle(): void
+    {
+        $request = DriverRequest::with('trip')->find($this->driverRequestId);
+
+        if (! $request || $request->status !== 'pending') {
+            return;
+        }
+
+        $request->update(['status' => 'expired']);
+
+        if ($request->trip?->status !== 'staffing_in_progress' || $request->trip?->assigned_driver_id) {
+            return;
+        }
+
+        ProcessNextDriverInChainJob::dispatchSync($request->trip_id, $this->rankedDriverIds, $this->currentIndex + 1);
+    }
+}

--- a/app/Jobs/TripStaffing/CheckGuideRequestTimeoutJob.php
+++ b/app/Jobs/TripStaffing/CheckGuideRequestTimeoutJob.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Jobs\TripStaffing;
+
+use App\Models\GuideRequest;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class CheckGuideRequestTimeoutJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public int $guideRequestId, public array $rankedGuideIds, public int $currentIndex)
+    {
+    }
+
+    public function handle(): void
+    {
+        $request = GuideRequest::with('trip')->find($this->guideRequestId);
+
+        if (! $request || $request->status !== 'pending') {
+            return;
+        }
+
+        $request->update(['status' => 'expired']);
+
+        if ($request->trip?->status !== 'staffing_in_progress' || $request->trip?->assigned_guide_id) {
+            return;
+        }
+
+        ProcessNextGuideInChainJob::dispatchSync($request->trip_id, $this->rankedGuideIds, $this->currentIndex + 1);
+    }
+}

--- a/app/Jobs/TripStaffing/ProcessNextDriverInChainJob.php
+++ b/app/Jobs/TripStaffing/ProcessNextDriverInChainJob.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Jobs\TripStaffing;
+
+use App\Domain\TripStaffing\DriverChain\SendToNextTripDriverHandler;
+use App\Models\Trip;
+use App\Services\TripStaffing\TripStaffingCoordinator;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ProcessNextDriverInChainJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public int $tripId, public array $rankedDriverIds, public int $index)
+    {
+    }
+
+    public function handle(TripStaffingCoordinator $coordinator): void
+    {
+        $trip = Trip::find($this->tripId);
+
+        if (! $trip || $trip->status !== 'staffing_in_progress' || $trip->assigned_driver_id) {
+            return;
+        }
+
+        if (! isset($this->rankedDriverIds[$this->index])) {
+            $coordinator->failTripStaffing($trip, 'Driver assignment timed out for all candidates.');
+
+            return;
+        }
+
+        $handler = new SendToNextTripDriverHandler();
+        $handler->handle($trip, $this->rankedDriverIds, $this->index);
+    }
+}

--- a/app/Jobs/TripStaffing/ProcessNextGuideInChainJob.php
+++ b/app/Jobs/TripStaffing/ProcessNextGuideInChainJob.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Jobs\TripStaffing;
+
+use App\Domain\TripStaffing\GuideChain\SendToNextGuideHandler;
+use App\Models\Trip;
+use App\Services\TripStaffing\TripStaffingCoordinator;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ProcessNextGuideInChainJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public int $tripId, public array $rankedGuideIds, public int $index)
+    {
+    }
+
+    public function handle(TripStaffingCoordinator $coordinator): void
+    {
+        $trip = Trip::find($this->tripId);
+
+        if (! $trip || $trip->status !== 'staffing_in_progress' || $trip->assigned_guide_id) {
+            return;
+        }
+
+        if (! isset($this->rankedGuideIds[$this->index])) {
+            $coordinator->failTripStaffing($trip, 'Guide assignment timed out for all candidates.');
+
+            return;
+        }
+
+        $handler = new SendToNextGuideHandler();
+        $handler->handle($trip, $this->rankedGuideIds, $this->index);
+    }
+}

--- a/app/Jobs/TripStaffing/ProcessTripDriverMatchingJob.php
+++ b/app/Jobs/TripStaffing/ProcessTripDriverMatchingJob.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Jobs\TripStaffing;
+
+use App\Domain\TripStaffing\DriverChain\SendToNextTripDriverHandler;
+use App\Models\Trip;
+use App\Services\TripStaffing\DriverRankingService;
+use App\Services\TripStaffing\TripStaffingCoordinator;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ProcessTripDriverMatchingJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public int $tripId)
+    {
+    }
+
+    public function handle(DriverRankingService $rankingService, TripStaffingCoordinator $coordinator): void
+    {
+        $trip = Trip::find($this->tripId);
+
+        if (! $trip || $trip->status !== 'staffing_in_progress' || $trip->assigned_driver_id) {
+            return;
+        }
+
+        $rankedDriverIds = $rankingService->rankedDriverIdsForTrip($trip);
+        $trip->update(['ranked_driver_ids' => $rankedDriverIds]);
+
+        if (empty($rankedDriverIds)) {
+            $coordinator->failTripStaffing($trip, 'No available drivers accepted requirements.');
+
+            return;
+        }
+
+        $handler = new SendToNextTripDriverHandler();
+        $handler->handle($trip, $rankedDriverIds, 0);
+    }
+}

--- a/app/Jobs/TripStaffing/ProcessTripGuideMatchingJob.php
+++ b/app/Jobs/TripStaffing/ProcessTripGuideMatchingJob.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Jobs\TripStaffing;
+
+use App\Domain\TripStaffing\GuideChain\SendToNextGuideHandler;
+use App\Models\Trip;
+use App\Services\TripStaffing\GuideRankingService;
+use App\Services\TripStaffing\TripStaffingCoordinator;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ProcessTripGuideMatchingJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public int $tripId)
+    {
+    }
+
+    public function handle(GuideRankingService $rankingService, TripStaffingCoordinator $coordinator): void
+    {
+        $trip = Trip::find($this->tripId);
+
+        if (! $trip || $trip->status !== 'staffing_in_progress' || $trip->assigned_guide_id) {
+            return;
+        }
+
+        $rankedGuideIds = $rankingService->rankedGuideIdsForTrip($trip);
+        $trip->update(['ranked_guide_ids' => $rankedGuideIds]);
+
+        if (empty($rankedGuideIds)) {
+            $coordinator->failTripStaffing($trip, 'No available guides accepted requirements.');
+
+            return;
+        }
+
+        $handler = new SendToNextGuideHandler();
+        $handler->handle($trip, $rankedGuideIds, 0);
+    }
+}

--- a/app/Jobs/TripStaffing/SendDriverRequestJob.php
+++ b/app/Jobs/TripStaffing/SendDriverRequestJob.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Jobs\TripStaffing;
+
+use App\Models\Driver;
+use App\Models\DriverRequest;
+use App\Models\Trip;
+use App\Notifications\DriverStaffingRequestNotification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Queue;
+
+class SendDriverRequestJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public int $tripId,
+        public int $driverId,
+        public array $rankedDriverIds,
+        public int $currentIndex,
+    ) {
+    }
+
+    public function handle(): void
+    {
+        $trip = Trip::find($this->tripId);
+        $driver = Driver::with('user')->find($this->driverId);
+
+        if (! $trip || ! $driver || $trip->status !== 'staffing_in_progress' || $trip->assigned_driver_id) {
+            return;
+        }
+
+        $request = DriverRequest::create([
+            'trip_id' => $trip->id,
+            'driver_id' => $driver->id,
+            'chain_index' => $this->currentIndex,
+            'status' => 'pending',
+            'expires_at' => now()->addDay(),
+        ]);
+
+        if ($driver->user) {
+            $driver->user->notify(new DriverStaffingRequestNotification($trip));
+        }
+
+        if (Queue::getDefaultDriver() !== 'sync') {
+            CheckDriverRequestTimeoutJob::dispatch($request->id, $this->rankedDriverIds, $this->currentIndex)
+                ->delay($request->expires_at);
+        }
+    }
+}

--- a/app/Jobs/TripStaffing/SendGuideRequestJob.php
+++ b/app/Jobs/TripStaffing/SendGuideRequestJob.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Jobs\TripStaffing;
+
+use App\Models\Guide;
+use App\Models\GuideRequest;
+use App\Models\Trip;
+use App\Notifications\GuideStaffingRequestNotification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Queue;
+
+class SendGuideRequestJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public int $tripId,
+        public int $guideId,
+        public array $rankedGuideIds,
+        public int $currentIndex,
+    ) {
+    }
+
+    public function handle(): void
+    {
+        $trip = Trip::find($this->tripId);
+        $guide = Guide::with('user')->find($this->guideId);
+
+        if (! $trip || ! $guide || $trip->status !== 'staffing_in_progress' || $trip->assigned_guide_id) {
+            return;
+        }
+
+        $request = GuideRequest::create([
+            'trip_id' => $trip->id,
+            'guide_id' => $guide->id,
+            'chain_index' => $this->currentIndex,
+            'status' => 'pending',
+            'expires_at' => now()->addDay(),
+        ]);
+
+        if ($guide->user) {
+            $guide->user->notify(new GuideStaffingRequestNotification($trip));
+        }
+
+        if (Queue::getDefaultDriver() !== 'sync') {
+            CheckGuideRequestTimeoutJob::dispatch($request->id, $this->rankedGuideIds, $this->currentIndex)
+                ->delay($request->expires_at);
+        }
+    }
+}

--- a/app/Jobs/TripStaffing/StartTripStaffingJob.php
+++ b/app/Jobs/TripStaffing/StartTripStaffingJob.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Jobs\TripStaffing;
+
+use App\Models\Trip;
+use App\Services\Trip\TripStateManager;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class StartTripStaffingJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public int $tripId)
+    {
+    }
+
+    public function handle(TripStateManager $stateManager): void
+    {
+        $trip = Trip::find($this->tripId);
+
+        if (! $trip || $trip->status !== 'ready_for_assignment') {
+            return;
+        }
+
+        $stateManager->transition($trip, 'staffing_in_progress');
+
+        ProcessTripGuideMatchingJob::dispatch($trip->id);
+        ProcessTripDriverMatchingJob::dispatch($trip->id);
+    }
+}

--- a/app/Models/Driver.php
+++ b/app/Models/Driver.php
@@ -45,6 +45,12 @@ class Driver extends Model
     }
 
 
+
+    public function driverRequests()
+    {
+        return $this->hasMany(DriverRequest::class);
+    }
+
     public function bookingRequests()
     {
     return $this->hasMany(BookingRequest::class);

--- a/app/Models/DriverRequest.php
+++ b/app/Models/DriverRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DriverRequest extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'trip_id',
+        'driver_id',
+        'chain_index',
+        'status',
+        'expires_at',
+        'responded_at',
+    ];
+
+    protected $casts = [
+        'expires_at' => 'datetime',
+        'responded_at' => 'datetime',
+    ];
+
+    public function trip()
+    {
+        return $this->belongsTo(Trip::class);
+    }
+
+    public function driver()
+    {
+        return $this->belongsTo(Driver::class);
+    }
+}

--- a/app/Models/Guide.php
+++ b/app/Models/Guide.php
@@ -42,6 +42,12 @@ class Guide extends Model
         return $this->hasMany(GuideAvailability::class);
     }
 
+
+    public function guideRequests()
+    {
+        return $this->hasMany(GuideRequest::class);
+    }
+
     public function assignments()
     {
         return $this->hasMany(GuideAssignment::class);

--- a/app/Models/GuideRequest.php
+++ b/app/Models/GuideRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class GuideRequest extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'trip_id',
+        'guide_id',
+        'chain_index',
+        'status',
+        'expires_at',
+        'responded_at',
+    ];
+
+    protected $casts = [
+        'expires_at' => 'datetime',
+        'responded_at' => 'datetime',
+    ];
+
+    public function trip()
+    {
+        return $this->belongsTo(Trip::class);
+    }
+
+    public function guide()
+    {
+        return $this->belongsTo(Guide::class);
+    }
+}

--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -27,6 +27,10 @@ class Trip extends Model
         'driver_vehicle_capacity',
         'driver_trip_type',
         'driver_road_type',
+        'ranked_guide_ids',
+        'ranked_driver_ids',
+        'assigned_guide_id',
+        'assigned_driver_id',
     ];
 
     protected $hidden = [
@@ -37,6 +41,8 @@ class Trip extends Model
     protected $casts = [
         'guide_specialization_ids' => 'array',
         'requires_tour_leader' => 'boolean',
+        'ranked_guide_ids' => 'array',
+        'ranked_driver_ids' => 'array',
     ];
 
    public function packages()
@@ -67,6 +73,27 @@ class Trip extends Model
     return $this->hasMany(GuideAssignment::class);
    }
    
+
+    public function guideRequests()
+    {
+        return $this->hasMany(GuideRequest::class);
+    }
+
+    public function driverRequests()
+    {
+        return $this->hasMany(DriverRequest::class);
+    }
+
+    public function assignedGuide()
+    {
+        return $this->belongsTo(Guide::class, 'assigned_guide_id');
+    }
+
+    public function assignedDriver()
+    {
+        return $this->belongsTo(Driver::class, 'assigned_driver_id');
+    }
+
     public function guides()
     {
         return $this->belongsToMany(Guide::class, 'guide_assignments')

--- a/app/Notifications/DriverStaffingRequestNotification.php
+++ b/app/Notifications/DriverStaffingRequestNotification.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Trip;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class DriverStaffingRequestNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(private Trip $trip)
+    {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'trip_id' => $this->trip->id,
+            'trip_name' => $this->trip->name,
+            'message' => 'You have a new driver staffing request.',
+        ];
+    }
+}

--- a/app/Notifications/GuideStaffingRequestNotification.php
+++ b/app/Notifications/GuideStaffingRequestNotification.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Trip;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class GuideStaffingRequestNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(private Trip $trip)
+    {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'trip_id' => $this->trip->id,
+            'trip_name' => $this->trip->name,
+            'message' => 'You have a new guide staffing request.',
+        ];
+    }
+}

--- a/app/Notifications/TripStaffingAdminNotification.php
+++ b/app/Notifications/TripStaffingAdminNotification.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class TripStaffingAdminNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(private string $message)
+    {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'message' => $this->message,
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,7 +3,9 @@
 namespace App\Providers;
 
 use App\Domain\TransportReservation\Ranking\DriverRankingStrategy;
+use App\Domain\TripStaffing\Ranking\GuideRankingStrategy;
 use App\Domain\TransportReservation\Ranking\LastTripAndTripsCountStrategy;
+use App\Domain\TripStaffing\Ranking\LastTripAndTripsCountGuideStrategy;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -15,6 +17,7 @@ class AppServiceProvider extends ServiceProvider
     {
         //
         $this->app->bind(DriverRankingStrategy::class, LastTripAndTripsCountStrategy::class);
+        $this->app->bind(GuideRankingStrategy::class, LastTripAndTripsCountGuideStrategy::class);
     }
 
     /**

--- a/app/Services/AiTrip/TripService.php
+++ b/app/Services/AiTrip/TripService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\AiTrip;
 
+use App\Jobs\TripStaffing\StartTripStaffingJob;
 use App\Models\DayActivity;
 use App\Models\Trip;
 use App\Models\TripDay;
@@ -267,6 +268,7 @@ class TripService
             ]);
 
             $this->tripStateManager->transition($trip, 'ready_for_assignment');
+            StartTripStaffingJob::dispatch($trip->id)->afterCommit();
         });
     }
 

--- a/app/Services/TripStaffing/DriverRankingService.php
+++ b/app/Services/TripStaffing/DriverRankingService.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Services\TripStaffing;
+
+use App\Domain\TransportReservation\Ranking\DriverRankingStrategy;
+use App\Models\Driver;
+use App\Models\Trip;
+
+class DriverRankingService
+{
+    public function __construct(private DriverRankingStrategy $strategy)
+    {
+    }
+
+    public function rankedDriverIdsForTrip(Trip $trip): array
+    {
+        $trip->loadMissing(['primaryDestination', 'schedules']);
+
+        $city = strtolower((string) optional($trip->primaryDestination)->city);
+        $country = strtolower((string) optional($trip->primaryDestination)->country);
+        $start = optional($trip->schedules->min('start_date'));
+        $end = optional($trip->schedules->max('end_date'));
+
+        $drivers = Driver::query()
+            ->whereIn('status', ['approved', 'Approved'])
+            ->whereHas('assignment', function ($assignmentQuery) use ($trip) {
+                $assignmentQuery->whereHas('vehicle', function ($vehicleQuery) use ($trip) {
+                    if (! empty($trip->driver_vehicle_type)) {
+                        $vehicleQuery->whereRaw('LOWER(type) = ?', [strtolower((string) $trip->driver_vehicle_type)]);
+                    }
+
+                    if (! empty($trip->driver_vehicle_capacity)) {
+                        $vehicleQuery->where('max_passengers', '>=', (int) $trip->driver_vehicle_capacity);
+                    }
+                });
+            })
+            ->when($city || $country, function ($query) use ($city, $country) {
+                $query->where(function ($locationQuery) use ($city, $country) {
+                    if ($city) {
+                        $locationQuery->orWhereRaw('LOWER(address) like ?', ["%{$city}%"]);
+                    }
+
+                    if ($country) {
+                        $locationQuery->orWhereRaw('LOWER(address) like ?', ["%{$country}%"]);
+                    }
+                });
+            })
+            ->with(['tripTransports.trip.schedules', 'reservations'])
+            ->get()
+            ->filter(function (Driver $driver) use ($start, $end) {
+                if (! $start || ! $end) {
+                    return true;
+                }
+
+                foreach ($driver->tripTransports as $transport) {
+                    foreach ($transport->trip?->schedules ?? [] as $schedule) {
+                        if ($schedule->start_date <= $end && $schedule->end_date >= $start) {
+                            return false;
+                        }
+                    }
+                }
+
+                foreach ($driver->reservations as $reservation) {
+                    if (! in_array($reservation->status, ['driver_assigned', 'confirmed'], true)) {
+                        continue;
+                    }
+
+                    $pickup = optional($reservation->pickup_datetime)?->toDateString();
+                    $dropoff = optional($reservation->dropoff_datetime)?->toDateString() ?? $pickup;
+
+                    if ($pickup && $dropoff && $pickup <= $end && $dropoff >= $start) {
+                        return false;
+                    }
+                }
+
+                return true;
+            })
+            ->values();
+
+        if ($drivers->isEmpty()) {
+            return [];
+        }
+
+        return $this->strategy->rank($drivers)->pluck('id')->all();
+    }
+}

--- a/app/Services/TripStaffing/GuideRankingService.php
+++ b/app/Services/TripStaffing/GuideRankingService.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Services\TripStaffing;
+
+use App\Domain\TripStaffing\Ranking\GuideRankingStrategy;
+use App\Models\Guide;
+use App\Models\Trip;
+
+class GuideRankingService
+{
+    public function __construct(private GuideRankingStrategy $strategy)
+    {
+    }
+
+    public function rankedGuideIdsForTrip(Trip $trip): array
+    {
+        $trip->loadMissing(['primaryDestination', 'schedules']);
+
+        $specializationIds = collect($trip->guide_specialization_ids ?? [])->map(fn ($id) => (int) $id)->filter()->values();
+        $city = strtolower((string) optional($trip->primaryDestination)->city);
+        $country = strtolower((string) optional($trip->primaryDestination)->country);
+        $start = optional($trip->schedules->min('start_date'));
+        $end = optional($trip->schedules->max('end_date'));
+
+        $guides = Guide::query()
+            ->whereIn('status', ['approved', 'Approved'])
+            ->when($trip->requires_tour_leader, fn ($query) => $query->where('is_tour_leader', true))
+            ->when($specializationIds->isNotEmpty(), function ($query) use ($specializationIds) {
+                $query->whereHas('specializations', fn ($spQuery) => $spQuery->whereIn('specializations.id', $specializationIds->all()));
+            })
+            ->when($city || $country, function ($query) use ($city, $country) {
+                $query->where(function ($locationQuery) use ($city, $country) {
+                    if ($city) {
+                        $locationQuery->orWhereRaw('LOWER(address) like ?', ["%{$city}%"]);
+                    }
+
+                    if ($country) {
+                        $locationQuery->orWhereRaw('LOWER(address) like ?', ["%{$country}%"]);
+                    }
+                });
+            })
+            ->where(function ($query) {
+                $query->whereNull('last_trip_at')->orWhere('last_trip_at', '<=', now()->subDays(6));
+            })
+            ->with(['assignments.trip.schedules'])
+            ->get()
+            ->filter(function (Guide $guide) use ($start, $end) {
+                if (! $start || ! $end) {
+                    return true;
+                }
+
+                foreach ($guide->assignments as $assignment) {
+                    if (! in_array($assignment->status, ['assigned', 'accepted'], true)) {
+                        continue;
+                    }
+
+                    foreach ($assignment->trip?->schedules ?? [] as $schedule) {
+                        if ($schedule->start_date <= $end && $schedule->end_date >= $start) {
+                            return false;
+                        }
+                    }
+                }
+
+                return true;
+            })
+            ->values();
+
+        if ($guides->isEmpty()) {
+            return [];
+        }
+
+        return $this->strategy->rank($guides)->pluck('id')->all();
+    }
+}

--- a/app/Services/TripStaffing/TripStaffingCoordinator.php
+++ b/app/Services/TripStaffing/TripStaffingCoordinator.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Services\TripStaffing;
+
+use App\Models\DriverRequest;
+use App\Models\GuideAssignment;
+use App\Models\GuideRequest;
+use App\Models\Trip;
+use App\Models\TripTransport;
+use App\Models\User;
+use App\Notifications\TripStaffingAdminNotification;
+use App\Services\Trip\TripStateManager;
+use Illuminate\Support\Facades\DB;
+
+class TripStaffingCoordinator
+{
+    public function __construct(private TripStateManager $stateManager)
+    {
+    }
+
+    public function acceptGuideRequest(GuideRequest $request): bool
+    {
+        return DB::transaction(function () use ($request) {
+            $request = GuideRequest::query()->lockForUpdate()->find($request->id);
+            $trip = Trip::query()->lockForUpdate()->find($request?->trip_id);
+
+            if (! $request || ! $trip || $request->status !== 'pending' || $trip->assigned_guide_id) {
+                return false;
+            }
+
+            $request->update(['status' => 'accepted', 'responded_at' => now()]);
+            $trip->update(['assigned_guide_id' => $request->guide_id]);
+
+            GuideAssignment::query()->updateOrCreate(
+                ['trip_id' => $trip->id, 'guide_id' => $request->guide_id],
+                ['status' => 'assigned']
+            );
+
+            $trip->guideRequests()->where('id', '!=', $request->id)->where('status', 'pending')->update(['status' => 'expired']);
+
+            $this->notifyAdmins("Guide assigned to trip #{$trip->id}.");
+            $this->progressTripIfFullyStaffed($trip->fresh());
+
+            return true;
+        });
+    }
+
+    public function acceptDriverRequest(DriverRequest $request): bool
+    {
+        return DB::transaction(function () use ($request) {
+            $request = DriverRequest::query()->lockForUpdate()->find($request->id);
+            $trip = Trip::query()->lockForUpdate()->find($request?->trip_id);
+
+            if (! $request || ! $trip || $request->status !== 'pending' || $trip->assigned_driver_id) {
+                return false;
+            }
+
+            $request->update(['status' => 'accepted', 'responded_at' => now()]);
+            $trip->update(['assigned_driver_id' => $request->driver_id]);
+
+            TripTransport::query()
+                ->where('trip_id', $trip->id)
+                ->whereNull('driver_id')
+                ->update(['driver_id' => $request->driver_id]);
+
+            $trip->driverRequests()->where('id', '!=', $request->id)->where('status', 'pending')->update(['status' => 'expired']);
+
+            $this->notifyAdmins("Driver assigned to trip #{$trip->id}.");
+            $this->progressTripIfFullyStaffed($trip->fresh());
+
+            return true;
+        });
+    }
+
+    public function rejectGuideRequest(GuideRequest $request): void
+    {
+        $request->update(['status' => 'rejected', 'responded_at' => now()]);
+    }
+
+    public function rejectDriverRequest(DriverRequest $request): void
+    {
+        $request->update(['status' => 'rejected', 'responded_at' => now()]);
+    }
+
+    public function failTripStaffing(Trip $trip, string $reason): void
+    {
+        if ($trip->status !== 'staffing_in_progress') {
+            return;
+        }
+
+        $this->stateManager->transition($trip, 'draft');
+        $this->notifyAdmins("Trip #{$trip->id} reverted to draft: {$reason}");
+    }
+
+    private function progressTripIfFullyStaffed(Trip $trip): void
+    {
+        if (! $trip->assigned_guide_id || ! $trip->assigned_driver_id) {
+            return;
+        }
+
+        if ($trip->status === 'staffing_in_progress') {
+            $this->stateManager->transition($trip, 'staffed');
+        }
+
+        if ($trip->fresh()->status === 'staffed') {
+            $this->stateManager->transition($trip, 'published');
+        }
+    }
+
+    private function notifyAdmins(string $message): void
+    {
+        User::query()
+            ->where('role', 'admin')
+            ->get()
+            ->each(fn (User $admin) => $admin->notify(new TripStaffingAdminNotification($message)));
+    }
+}

--- a/database/migrations/2026_04_09_130000_create_guide_driver_requests_tables.php
+++ b/database/migrations/2026_04_09_130000_create_guide_driver_requests_tables.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('guide_requests', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('trip_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('guide_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('chain_index')->default(0);
+            $table->string('status')->default('pending');
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamp('responded_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['trip_id', 'status']);
+            $table->index(['guide_id', 'status']);
+        });
+
+        Schema::create('driver_requests', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('trip_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('driver_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('chain_index')->default(0);
+            $table->string('status')->default('pending');
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamp('responded_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['trip_id', 'status']);
+            $table->index(['driver_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('driver_requests');
+        Schema::dropIfExists('guide_requests');
+    }
+};

--- a/database/migrations/2026_04_09_131000_add_staffing_chain_columns_to_trips_table.php
+++ b/database/migrations/2026_04_09_131000_add_staffing_chain_columns_to_trips_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->json('ranked_guide_ids')->nullable()->after('driver_road_type');
+            $table->json('ranked_driver_ids')->nullable()->after('ranked_guide_ids');
+            $table->foreignId('assigned_guide_id')->nullable()->after('ranked_driver_ids')->constrained('guides')->nullOnDelete();
+            $table->foreignId('assigned_driver_id')->nullable()->after('assigned_guide_id')->constrained('drivers')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->dropForeign(['assigned_guide_id']);
+            $table->dropForeign(['assigned_driver_id']);
+            $table->dropColumn(['ranked_guide_ids', 'ranked_driver_ids', 'assigned_guide_id', 'assigned_driver_id']);
+        });
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,8 @@ use App\Http\Controllers\ShiftTemplateController;
 use App\Http\Controllers\AssignmentController;
 use App\Http\Controllers\Auth\AuthenticatedSessionController;
 use App\Http\Controllers\Driver\BookingRequestController;
+use App\Http\Controllers\Driver\TripDriverRequestResponseController;
+use App\Http\Controllers\Guide\GuideRequestResponseController;
 use App\Http\Controllers\SpecializationController;
 use App\Http\Controllers\AdminGuideController;
 use App\Http\Controllers\AdminGuideApplicationController;
@@ -245,6 +247,11 @@ Route::post('/trips/{trip}/complete/schedules', [AiTripCompletionController::cla
 Route::post('/trips/{trip}/complete/images', [AiTripCompletionController::class, 'saveImages'])->name('trip.complete.images');
 Route::post('/trips/{trip}/complete/guides', [AiTripCompletionController::class, 'saveGuides'])->name('trip.complete.guides');
 Route::post('/trips/{trip}/complete/drivers', [AiTripCompletionController::class, 'saveDrivers'])->name('trip.complete.drivers');
+
+Route::post('/guide-requests/{guideRequest}/accept', [GuideRequestResponseController::class, 'accept'])->name('guide.requests.accept');
+Route::post('/guide-requests/{guideRequest}/reject', [GuideRequestResponseController::class, 'reject'])->name('guide.requests.reject');
+Route::post('/trip-driver-requests/{driverRequest}/accept', [TripDriverRequestResponseController::class, 'accept'])->name('trip.driver.requests.accept');
+Route::post('/trip-driver-requests/{driverRequest}/reject', [TripDriverRequestResponseController::class, 'reject'])->name('trip.driver.requests.reject');
 
 //Activities routes
 Route::get('/activities',[ActivityController::class,'index'])->name('activities.index');


### PR DESCRIPTION
### Motivation
- Automate the Guide and Driver staffing phase that must start only after the final Driver-step save in the AI "Complete Trip" flow and follow the same clean architecture used by Transport Reservation. 
- Ensure candidate filtering, ranking and sequential requests are handled asynchronously so admins cannot directly assign staff and heavy operations run in queues. 
- Provide robust first-accept-wins semantics with automatic expiry/retry and clear trip state transitions for staffing lifecycle. 

### Description
- Added a queued staffing kickoff on final save: `saveDrivers` now transitions a `Trip` to `ready_for_assignment` and dispatches `StartTripStaffingJob` (`app/Services/AiTrip/TripService.php`).
- Implemented ranking/filtering services and Strategy bindings: `GuideRankingService` and `DriverRankingService` and a `LastTripAndTripsCountGuideStrategy` with DI binding in `AppServiceProvider` to reuse existing ranking pattern (`app/Services/TripStaffing`, `app/Domain/TripStaffing/Ranking`).
- Implemented Chain of Responsibility + jobs to sequentially send requests: chain handlers and jobs for send/timeout/next processing for guides and drivers (`app/Domain/TripStaffing/*`, `app/Jobs/TripStaffing/*`).
- Added request persistence and lifecycle: `guide_requests` and `driver_requests` migrations plus `GuideRequest`/`DriverRequest` models and trip columns `ranked_*_ids` and `assigned_*_id` (`database/migrations/*`, `app/Models/*`, `app/Models/Trip.php`).
- Added coordinator logic and response controllers to enforce "first accept wins", expire other pending requests, notify admins, and progress trip states to `staffed` / `published` or revert to `draft` when staffing fails (`app/Services/TripStaffing/TripStaffingCoordinator.php`, `app/Http/Controllers/Guide/GuideRequestResponseController.php`, `app/Http/Controllers/Driver/TripDriverRequestResponseController.php`).
- Updated Trip state rules to allow `ready_for_assignment -> staffing_in_progress` and `staffing_in_progress -> draft` fallback (`app/Domain/Trip/States/*`) and added routes for request responses (`routes/web.php`).

### Testing
- Ran PHP syntax checks across changed PHP files with `php -l` and a bulk `php -l` check, and all modified/added PHP files passed linting successfully. 
- Executed focused file-level syntax scans for the new TripStaffing classes and migrations and they reported no syntax errors. 
- Attempted to run `php artisan test --filter=AssignmentControllerTest` but it failed due to the environment missing installed dependencies (`vendor/autoload.php`), not due to code syntax or logic in the change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7a97e96f0832f837b5d0d9ea16bb4)