### PR TITLE
Enhance trip/guide/driver factories and add staffing scenario tests

### DIFF
--- a/database/factories/DriverFactory.php
+++ b/database/factories/DriverFactory.php
@@ -2,15 +2,25 @@
 
 namespace Database\Factories;
 
-use Illuminate\Database\Eloquent\Factories\Factory;
-use App\Models\User;
 use App\Enums\UserRole;
+use App\Models\Assignment;
+use App\Models\Driver;
+use App\Models\ShiftTemplate;
+use App\Models\TransportReservation;
+use App\Models\TransportVehicle;
+use App\Models\Trip;
+use App\Models\TripTransport;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Driver>
  */
 class DriverFactory extends Factory
 {
+    protected $model = Driver::class;
+
     public function definition(): array
     {
         return [
@@ -18,7 +28,7 @@ class DriverFactory extends Factory
                 'role' => UserRole::DRIVER->value,
             ]),
             'age' => fake()->numberBetween(21, 60),
-            'address' => fake()->address(),
+            'address' => 'Beirut, Lebanon',
             'license_image' => fake()->uuid() . '.jpg',
             'experience' => fake()->randomElement([
                 '1 year experience',
@@ -30,19 +40,137 @@ class DriverFactory extends Factory
             ]),
             'license_category' => fake()->randomElement(['A', 'B']),
             'personal_image' => fake()->uuid() . '.jpg',
-            'date_of_hire' => fake()->date(),
-            'status' => 'pending', // default منطقي
-            'last_trip_at' => fake()->optional()->dateTimeBetween('-3 months', 'now'),
+            'date_of_hire' => '2020-01-01',
+            'status' => 'pending',
+            'last_trip_at' => CarbonImmutable::parse('2026-03-20 09:00:00'),
             'total_trips_count' => fake()->numberBetween(0, 250),
             'earnings_balance' => fake()->randomFloat(2, 0, 10000),
         ];
     }
 
-    // State للسائق approved
-    public function approved()
+    public function approved(): static
     {
         return $this->state(fn () => [
             'status' => 'approved',
         ]);
+    }
+
+    public function accepted(): static
+    {
+        return $this->approved();
+    }
+
+    public function locatedIn(string $city, string $country): static
+    {
+        return $this->state(fn () => [
+            'address' => "{$city}, {$country}",
+        ]);
+    }
+
+    public function withAssignment(?TransportVehicle $vehicle = null): static
+    {
+        return $this->afterCreating(function (Driver $driver) use ($vehicle): void {
+            $assignedVehicle = $vehicle ?? TransportVehicle::factory()->create();
+
+            Assignment::query()->updateOrCreate(
+                ['driver_id' => $driver->id],
+                [
+                    'transport_vehicle_id' => $assignedVehicle->id,
+                    'shift_template_id' => ShiftTemplate::factory()->create()->id,
+                ]
+            );
+        });
+    }
+
+    public function matchingTrip(Trip $trip): static
+    {
+        return $this
+            ->approved()
+            ->state(fn () => [
+                'address' => trim(($trip->primaryDestination?->city ?? 'Beirut') . ', ' . ($trip->primaryDestination?->country ?? 'Lebanon'), ', '),
+                'last_trip_at' => now()->subDays(10),
+            ])
+            ->afterCreating(function (Driver $driver) use ($trip): void {
+                $vehicle = TransportVehicle::factory()->create([
+                    'type' => $trip->driver_vehicle_type ?? 'van',
+                    'max_passengers' => max((int) ($trip->driver_vehicle_capacity ?? 1), 1),
+                ]);
+
+                Assignment::query()->updateOrCreate(
+                    ['driver_id' => $driver->id],
+                    [
+                        'transport_vehicle_id' => $vehicle->id,
+                        'shift_template_id' => ShiftTemplate::factory()->create()->id,
+                    ]
+                );
+            });
+    }
+
+    public function failingCapacity(Trip $trip): static
+    {
+        return $this->approved()->afterCreating(function (Driver $driver) use ($trip): void {
+            $required = max((int) ($trip->driver_vehicle_capacity ?? 4), 1);
+
+            $vehicle = TransportVehicle::factory()->create([
+                'type' => $trip->driver_vehicle_type ?? 'van',
+                'max_passengers' => max(1, $required - 1),
+            ]);
+
+            Assignment::query()->updateOrCreate(
+                ['driver_id' => $driver->id],
+                [
+                    'transport_vehicle_id' => $vehicle->id,
+                    'shift_template_id' => ShiftTemplate::factory()->create()->id,
+                ]
+            );
+        });
+    }
+
+    public function failingLocation(): static
+    {
+        return $this->state(fn () => [
+            'address' => 'Tokyo, Japan',
+        ]);
+    }
+
+    public function unavailableForTrip(Trip $trip): static
+    {
+        return $this->matchingTrip($trip)->afterCreating(function (Driver $driver) use ($trip): void {
+            $schedule = $trip->schedules()->orderBy('start_date')->first();
+
+            if (! $schedule) {
+                return;
+            }
+
+            $vehicleId = Assignment::query()->where('driver_id', $driver->id)->value('transport_vehicle_id');
+            if (! $vehicleId) {
+                return;
+            }
+
+            $conflictingTrip = Trip::factory()
+                ->staffingWindow($schedule->start_date, 2)
+                ->create([
+                    'destination_id' => $trip->destination_id,
+                    'status' => 'published',
+                ]);
+
+            TripTransport::query()->create([
+                'trip_id' => $conflictingTrip->id,
+                'transport_vehicle_id' => $vehicleId,
+                'driver_id' => $driver->id,
+                'transport_type' => 'daily_transport',
+                'departure_time' => '09:00:00',
+                'return_time' => '17:00:00',
+                'notes' => 'Conflicting transport assignment',
+            ]);
+
+            TransportReservation::factory()->create([
+                'driver_id' => $driver->id,
+                'transport_vehicle_id' => $vehicleId,
+                'pickup_datetime' => CarbonImmutable::parse($schedule->start_date . ' 10:00:00'),
+                'dropoff_datetime' => CarbonImmutable::parse($schedule->end_date . ' 13:00:00'),
+                'status' => 'driver_assigned',
+            ]);
+        });
     }
 }

--- a/database/factories/GuideAvailabilityFactory.php
+++ b/database/factories/GuideAvailabilityFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Guide;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\GuideAvailability>
+ */
+class GuideAvailabilityFactory extends Factory
+{
+    public function definition(): array
+    {
+        $date = CarbonImmutable::parse('2026-06-15')->addDays(fake()->numberBetween(0, 14));
+
+        return [
+            'guide_id' => Guide::factory()->approved(),
+            'date' => $date->toDateString(),
+            'start_time' => '08:00:00',
+            'end_time' => '17:00:00',
+        ];
+    }
+}

--- a/database/factories/GuideFactory.php
+++ b/database/factories/GuideFactory.php
@@ -2,67 +2,159 @@
 
 namespace Database\Factories;
 
-use Illuminate\Database\Eloquent\Factories\Factory;
-use App\Models\User;
-use App\Models\Guide;
 use App\Enums\UserRole;
+use App\Models\Guide;
+use App\Models\GuideAssignment;
+use App\Models\Specialization;
+use App\Models\Trip;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Guide>
  */
 class GuideFactory extends Factory
 {
-    /**
-     * Define the model's default state.
-     *
-     * @return array<string, mixed>
-     */
+    protected $model = Guide::class;
+
     public function definition(): array
     {
         return [
             'user_id' => User::factory()->state([
                 'role' => UserRole::GUIDE->value,
             ]),
-
-            'bio' => $this->faker->paragraph(),
-            'languages' => $this->faker->randomElement([
+            'bio' => fake()->paragraph(),
+            'languages' => fake()->randomElement([
                 'English',
                 'English, Arabic',
                 'English, French',
-                'English, Spanish'
+                'English, Spanish',
             ]),
-
-            'years_of_experience' => $this->faker->numberBetween(1,15),
+            'years_of_experience' => fake()->numberBetween(1, 15),
             'certificate_image' => 'certificates/sample.jpg',
-            'status' => $this->faker->randomElement([
-                'pending',
-                'approved',
-                'rejected'
-            ]),
-            
-            'earnings_balance' => $this->faker->randomFloat(2,0,5000),
+            'status' => 'pending',
+            'earnings_balance' => fake()->randomFloat(2, 0, 5000),
             'personal_image' => 'guides/profile.jpg',
-            'age' => $this->faker->numberBetween(22,50),
-            'address' => $this->faker->address(),
-            'date_of_hire' => null,
+            'age' => fake()->numberBetween(22, 50),
+            'address' => 'Beirut, Lebanon',
+            'date_of_hire' => '2020-01-01',
             'total_trips_count' => 0,
             'last_trip_at' => null,
-            'is_tour_leader' => $this->faker->boolean()
+            'is_tour_leader' => false,
         ];
     }
 
-    /**
- * State: guide approved
- */
+    public function approved(): static
+    {
+        return $this->state(fn () => [
+            'status' => 'approved',
+            'date_of_hire' => '2020-01-01',
+            'last_trip_at' => CarbonImmutable::parse('2026-04-01 10:00:00'),
+        ]);
+    }
 
-        public function approved()
-        {
-            return $this->state(fn()=> [
-                'status' => 'approved',
-                'address' => $this->faker->address(),
-                'date_of_hire' => $this->faker->date(),
-                'total_trips_count' => $this->faker->numberBetween(0,100),
-                'last_trip_at' => $this->faker->dateTime(),
+    public function accepted(): static
+    {
+        return $this->approved();
+    }
+
+    public function tourLeader(): static
+    {
+        return $this->state(fn () => [
+            'is_tour_leader' => true,
+        ]);
+    }
+
+    public function locatedIn(string $city, string $country): static
+    {
+        return $this->state(fn () => [
+            'address' => "{$city}, {$country}",
+        ]);
+    }
+
+    public function recentlyAssigned(int $daysAgo = 3): static
+    {
+        return $this->state(fn () => [
+            'last_trip_at' => now()->subDays($daysAgo),
+        ]);
+    }
+
+    public function rested(int $daysAgo = 10): static
+    {
+        return $this->state(fn () => [
+            'last_trip_at' => now()->subDays($daysAgo),
+        ]);
+    }
+
+    public function withSpecializations(array $specializationIds): static
+    {
+        return $this->afterCreating(function (Guide $guide) use ($specializationIds): void {
+            $ids = collect($specializationIds)->filter()->map(fn ($id) => (int) $id)->values()->all();
+
+            if (! empty($ids)) {
+                $guide->specializations()->syncWithoutDetaching($ids);
+            }
+        });
+    }
+
+    public function matchingTrip(Trip $trip): static
+    {
+        return $this
+            ->approved()
+            ->state(fn () => [
+                'address' => trim(($trip->primaryDestination?->city ?? 'Beirut') . ', ' . ($trip->primaryDestination?->country ?? 'Lebanon'), ', '),
+                'is_tour_leader' => (bool) $trip->requires_tour_leader,
+                'last_trip_at' => now()->subDays(10),
+            ])
+            ->afterCreating(function (Guide $guide) use ($trip): void {
+                $specializationIds = collect($trip->guide_specialization_ids ?? [])->map(fn ($id) => (int) $id)->filter()->values();
+
+                if ($specializationIds->isEmpty()) {
+                    $specializationIds = collect([
+                        Specialization::factory()->create(['name' => 'City Tours'])->id,
+                    ]);
+                }
+
+                $guide->specializations()->syncWithoutDetaching($specializationIds->all());
+            });
+    }
+
+    public function nonMatchingSpecialization(Trip $trip): static
+    {
+        return $this->approved()->afterCreating(function (Guide $guide) use ($trip): void {
+            $required = collect($trip->guide_specialization_ids ?? [])->map(fn ($id) => (int) $id)->filter();
+
+            $specialization = Specialization::factory()->create();
+            if ($required->contains($specialization->id)) {
+                $specialization = Specialization::factory()->create();
+            }
+
+            $guide->specializations()->sync([$specialization->id]);
+        });
+    }
+
+    public function unavailableForTrip(Trip $trip): static
+    {
+        return $this->matchingTrip($trip)->afterCreating(function (Guide $guide) use ($trip): void {
+            $schedule = $trip->schedules()->orderBy('start_date')->first();
+
+            if (! $schedule) {
+                return;
+            }
+
+            $conflictingTrip = Trip::factory()
+                ->staffingWindow($schedule->start_date, 2)
+                ->create([
+                    'destination_id' => $trip->destination_id,
+                    'status' => 'published',
+                ]);
+
+            GuideAssignment::query()->create([
+                'trip_id' => $conflictingTrip->id,
+                'guide_id' => $guide->id,
+                'status' => 'assigned',
             ]);
-        }
+        });
+    }
 }

--- a/database/factories/TripDayFactory.php
+++ b/database/factories/TripDayFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Hotel;
+use App\Models\Trip;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\TripDay>
+ */
+class TripDayFactory extends Factory
+{
+    public function definition(): array
+    {
+        $dayNumber = fake()->numberBetween(1, 7);
+
+        return [
+            'trip_id' => Trip::factory(),
+            'day_number' => $dayNumber,
+            'title' => "Day {$dayNumber}",
+            'description' => fake()->sentence(10),
+            'highlights' => [fake()->sentence(4), fake()->sentence(4)],
+            'hotel_id' => Hotel::factory(),
+        ];
+    }
+}

--- a/database/factories/TripFactory.php
+++ b/database/factories/TripFactory.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Destination;
+use App\Models\Trip;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Trip>
+ */
+class TripFactory extends Factory
+{
+    private const DEFAULT_START_DATE = '2026-06-15';
+
+    protected $model = Trip::class;
+
+    public function definition(): array
+    {
+        $name = sprintf('Trip %04d', fake()->unique()->numberBetween(1, 9999));
+
+        return [
+            'destination_id' => Destination::factory(),
+            'name' => $name,
+            'slug' => str($name)->slug() . '-' . fake()->unique()->numerify('##'),
+            'description' => fake()->paragraph(),
+            'duration_days' => 3,
+            'category' => fake()->randomElement(['adventure', 'cultural', 'family', 'city']),
+            'max_participants' => 12,
+            'meeting_point_description' => 'Main square meeting point',
+            'meeting_point_address' => 'Downtown district',
+            'is_ai_generated' => false,
+            'ai_prompt' => null,
+            'status' => 'ready_for_assignment',
+            'guide_specialization_ids' => [],
+            'requires_tour_leader' => true,
+            'driver_vehicle_type' => 'van',
+            'driver_vehicle_capacity' => 8,
+            'driver_trip_type' => 'intercity',
+            'driver_road_type' => 'highway',
+            'ranked_guide_ids' => null,
+            'ranked_driver_ids' => null,
+            'assigned_guide_id' => null,
+            'assigned_driver_id' => null,
+        ];
+    }
+
+    public function configure(): static
+    {
+        return $this
+            ->afterCreating(function (Trip $trip): void {
+                if ($trip->schedules()->exists()) {
+                    return;
+                }
+
+                $start = CarbonImmutable::parse(self::DEFAULT_START_DATE);
+                $duration = max(1, (int) $trip->duration_days);
+
+                $trip->schedules()->create([
+                    'start_date' => $start->toDateString(),
+                    'end_date' => $start->addDays($duration - 1)->toDateString(),
+                    'booking_deadline' => $start->subDays(10)->toDateString(),
+                    'available_seats' => $trip->max_participants,
+                    'price_modifier' => 0,
+                    'status' => 'available',
+                ]);
+
+                if (! $trip->days()->exists()) {
+                    for ($day = 1; $day <= $duration; $day++) {
+                        $trip->days()->create([
+                            'day_number' => $day,
+                            'title' => "Day {$day}",
+                            'description' => "Activities planned for day {$day}.",
+                            'highlights' => ["Highlight {$day}"],
+                        ]);
+                    }
+                }
+            });
+    }
+
+    public function withMultipleSchedules(int $count = 2, ?string $firstStartDate = null): static
+    {
+        return $this->afterCreating(function (Trip $trip) use ($count, $firstStartDate): void {
+            $trip->schedules()->delete();
+
+            $start = CarbonImmutable::parse($firstStartDate ?? self::DEFAULT_START_DATE);
+            $duration = max(1, (int) $trip->duration_days);
+
+            for ($index = 0; $index < max(1, $count); $index++) {
+                $windowStart = $start->addDays($index * ($duration + 2));
+
+                $trip->schedules()->create([
+                    'start_date' => $windowStart->toDateString(),
+                    'end_date' => $windowStart->addDays($duration - 1)->toDateString(),
+                    'booking_deadline' => $windowStart->subDays(7)->toDateString(),
+                    'available_seats' => $trip->max_participants,
+                    'price_modifier' => 0,
+                    'status' => 'available',
+                ]);
+            }
+        });
+    }
+
+    public function staffingWindow(string $startDate, int $durationDays = 3): static
+    {
+        return $this->state(fn () => [
+            'duration_days' => max(1, $durationDays),
+        ])->afterCreating(function (Trip $trip) use ($startDate): void {
+            $trip->schedules()->delete();
+
+            $start = CarbonImmutable::parse($startDate);
+            $duration = max(1, (int) $trip->duration_days);
+
+            $trip->schedules()->create([
+                'start_date' => $start->toDateString(),
+                'end_date' => $start->addDays($duration - 1)->toDateString(),
+                'booking_deadline' => $start->subDays(8)->toDateString(),
+                'available_seats' => $trip->max_participants,
+                'price_modifier' => 0,
+                'status' => 'available',
+            ]);
+
+            $trip->days()->delete();
+            for ($day = 1; $day <= $duration; $day++) {
+                $trip->days()->create([
+                    'day_number' => $day,
+                    'title' => "Day {$day}",
+                    'description' => "Staffing scenario day {$day}",
+                    'highlights' => ["Scenario highlight {$day}"],
+                ]);
+            }
+        });
+    }
+}

--- a/database/factories/TripScheduleFactory.php
+++ b/database/factories/TripScheduleFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Trip;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\TripSchedule>
+ */
+class TripScheduleFactory extends Factory
+{
+    public function definition(): array
+    {
+        $start = CarbonImmutable::parse('2026-06-15')->addDays(fake()->numberBetween(0, 30));
+        $duration = fake()->numberBetween(1, 7);
+
+        return [
+            'trip_id' => Trip::factory(),
+            'start_date' => $start->toDateString(),
+            'end_date' => $start->addDays($duration - 1)->toDateString(),
+            'booking_deadline' => $start->subDays(7)->toDateString(),
+            'available_seats' => fake()->numberBetween(4, 24),
+            'price_modifier' => fake()->randomFloat(2, -15, 25),
+            'status' => 'available',
+        ];
+    }
+}

--- a/database/factories/TripTransportFactory.php
+++ b/database/factories/TripTransportFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Driver;
+use App\Models\TransportVehicle;
+use App\Models\Trip;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\TripTransport>
+ */
+class TripTransportFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'trip_id' => Trip::factory(),
+            'transport_vehicle_id' => TransportVehicle::factory(),
+            'driver_id' => null,
+            'transport_type' => fake()->randomElement(['arrival_transfer', 'daily_transport', 'departure_transfer']),
+            'departure_time' => '08:00:00',
+            'return_time' => '18:00:00',
+            'notes' => fake()->sentence(8),
+        ];
+    }
+
+    public function withDriver(Driver $driver): static
+    {
+        return $this->state(fn () => [
+            'driver_id' => $driver->id,
+        ]);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,7 +15,8 @@ class DatabaseSeeder extends Seeder
             DestinationSeeder::class,
             HotelSeeder::class,
             ActivitySeeder::class,
+            SpecializationSeeder::class,
+            TripStaffingScenarioSeeder::class,
         ]);
     }
 }
-

--- a/database/seeders/SpecializationSeeder.php
+++ b/database/seeders/SpecializationSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Specialization;
+use Illuminate\Database\Seeder;
+
+class SpecializationSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $names = [
+            'City Tours',
+            'Historical Tours',
+            'Nature Exploration',
+            'Museum Tours',
+            'Food Tours',
+        ];
+
+        foreach ($names as $name) {
+            Specialization::query()->updateOrCreate(['name' => $name], ['name' => $name]);
+        }
+    }
+}

--- a/database/seeders/TripStaffingScenarioSeeder.php
+++ b/database/seeders/TripStaffingScenarioSeeder.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\UserRole;
+use App\Jobs\TripStaffing\StartTripStaffingJob;
+use App\Models\Driver;
+use App\Models\Guide;
+use App\Models\Specialization;
+use App\Models\Trip;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class TripStaffingScenarioSeeder extends Seeder
+{
+    public function run(): void
+    {
+        User::query()->updateOrCreate(
+            ['email' => 'admin.staffing@example.com'],
+            [
+                'name' => 'Staffing',
+                'last_name' => 'Admin',
+                'phone_number' => '70000000',
+                'country' => 'Lebanon',
+                'password' => bcrypt('password'),
+                'role' => UserRole::ADMIN->value,
+                'email_verified_at' => now(),
+            ]
+        );
+
+        $destination = \App\Models\Destination::query()->firstOrCreate(
+            ['name' => 'Beirut Downtown'],
+            [
+                'city' => 'Beirut',
+                'country' => 'Lebanon',
+                'description' => 'Historic downtown with museums, local culture, and sea views.',
+                'location_details' => 'Downtown district',
+                'iata_code' => 'BEY',
+                'timezone' => 'Asia/Beirut',
+                'language' => 'ar',
+                'currency' => 'LBP',
+                'nearest_airport' => 'Rafic Hariri International Airport',
+                'best_time_to_visit' => 'Spring',
+                'emergency_numbers' => '112',
+                'local_tip' => 'Try local breakfast early in the morning.',
+            ]
+        );
+
+        $cityTours = Specialization::query()->firstOrCreate(['name' => 'City Tours']);
+        $historicalTours = Specialization::query()->firstOrCreate(['name' => 'Historical Tours']);
+        $natureTours = Specialization::query()->firstOrCreate(['name' => 'Nature Exploration']);
+
+        $this->seedPerfectMatchScenario($destination->id, $cityTours->id);
+        $this->seedPartialMatchScenario($destination->id, $historicalTours->id);
+        $this->seedConflictScenario($destination->id, $natureTours->id);
+        $this->seedRankingScenario($destination->id, $cityTours->id);
+    }
+
+    private function seedPerfectMatchScenario(int $destinationId, int $specializationId): void
+    {
+        $trip = Trip::factory()->staffingWindow('2026-06-15', 3)->create([
+            'destination_id' => $destinationId,
+            'name' => 'Staffing Demo - Perfect Match',
+            'slug' => 'staffing-demo-perfect-match',
+            'status' => 'ready_for_assignment',
+            'guide_specialization_ids' => [$specializationId],
+            'requires_tour_leader' => true,
+            'driver_vehicle_type' => 'van',
+            'driver_vehicle_capacity' => 6,
+            'driver_trip_type' => 'intercity',
+            'driver_road_type' => 'highway',
+        ]);
+
+        Guide::factory()->matchingTrip($trip)->create(['total_trips_count' => 1]);
+        Guide::factory()->nonMatchingSpecialization($trip)->create();
+        Guide::factory()->unavailableForTrip($trip)->create();
+        Guide::factory()->matchingTrip($trip)->recentlyAssigned(2)->create();
+
+        Driver::factory()->matchingTrip($trip)->create(['total_trips_count' => 1]);
+        Driver::factory()->failingCapacity($trip)->create();
+        Driver::factory()->matchingTrip($trip)->failingLocation()->create();
+        Driver::factory()->unavailableForTrip($trip)->create();
+
+        StartTripStaffingJob::dispatch($trip->id);
+    }
+
+    private function seedPartialMatchScenario(int $destinationId, int $specializationId): void
+    {
+        $trip = Trip::factory()->staffingWindow('2026-07-03', 2)->create([
+            'destination_id' => $destinationId,
+            'name' => 'Staffing Demo - Partial Match',
+            'slug' => 'staffing-demo-partial-match',
+            'status' => 'ready_for_assignment',
+            'guide_specialization_ids' => [$specializationId],
+            'requires_tour_leader' => false,
+            'driver_vehicle_type' => 'suv',
+            'driver_vehicle_capacity' => 8,
+            'driver_trip_type' => 'intercity',
+            'driver_road_type' => 'city',
+        ]);
+
+        Guide::factory()->matchingTrip($trip)->create();
+
+        Driver::factory()->failingCapacity($trip)->create();
+        Driver::factory()->matchingTrip($trip)->failingLocation()->create();
+
+        StartTripStaffingJob::dispatch($trip->id);
+    }
+
+    private function seedConflictScenario(int $destinationId, int $specializationId): void
+    {
+        $trip = Trip::factory()->staffingWindow('2026-08-10', 4)->create([
+            'destination_id' => $destinationId,
+            'name' => 'Staffing Demo - Conflict',
+            'slug' => 'staffing-demo-conflict',
+            'status' => 'ready_for_assignment',
+            'guide_specialization_ids' => [$specializationId],
+            'requires_tour_leader' => false,
+            'driver_vehicle_type' => 'van',
+            'driver_vehicle_capacity' => 5,
+            'driver_trip_type' => 'mountain',
+            'driver_road_type' => 'mixed',
+        ]);
+
+        Guide::factory()->matchingTrip($trip)->create();
+        Guide::factory()->unavailableForTrip($trip)->create();
+
+        Driver::factory()->matchingTrip($trip)->create();
+        Driver::factory()->unavailableForTrip($trip)->create();
+
+        StartTripStaffingJob::dispatch($trip->id);
+    }
+
+    private function seedRankingScenario(int $destinationId, int $specializationId): void
+    {
+        $trip = Trip::factory()->staffingWindow('2026-09-20', 2)->create([
+            'destination_id' => $destinationId,
+            'name' => 'Staffing Demo - Ranking',
+            'slug' => 'staffing-demo-ranking',
+            'status' => 'ready_for_assignment',
+            'guide_specialization_ids' => [$specializationId],
+            'requires_tour_leader' => false,
+            'driver_vehicle_type' => 'van',
+            'driver_vehicle_capacity' => 4,
+            'driver_trip_type' => 'intercity',
+            'driver_road_type' => 'highway',
+        ]);
+
+        Guide::factory()->matchingTrip($trip)->create([
+            'total_trips_count' => 1,
+            'last_trip_at' => now()->subDays(60),
+        ]);
+
+        Guide::factory()->matchingTrip($trip)->create([
+            'total_trips_count' => 4,
+            'last_trip_at' => now()->subDays(120),
+        ]);
+
+        Driver::factory()->matchingTrip($trip)->create([
+            'total_trips_count' => 1,
+            'last_trip_at' => now()->subDays(30),
+        ]);
+
+        Driver::factory()->matchingTrip($trip)->create([
+            'total_trips_count' => 3,
+            'last_trip_at' => now()->subDays(90),
+        ]);
+
+        StartTripStaffingJob::dispatch($trip->id);
+    }
+}

--- a/tests/Feature/TripStaffing/TripStaffingFactoryScenariosTest.php
+++ b/tests/Feature/TripStaffing/TripStaffingFactoryScenariosTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Tests\Feature\TripStaffing;
+
+use App\Jobs\TripStaffing\ProcessTripDriverMatchingJob;
+use App\Jobs\TripStaffing\ProcessTripGuideMatchingJob;
+use App\Models\DriverRequest;
+use App\Models\GuideRequest;
+use App\Models\Specialization;
+use App\Models\Trip;
+use App\Services\TripStaffing\DriverRankingService;
+use App\Services\TripStaffing\GuideRankingService;
+use Carbon\CarbonImmutable;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TripStaffingFactoryScenariosTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow(CarbonImmutable::parse('2026-06-01 09:00:00'));
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_perfect_match_case_generates_and_sends_requests_only_to_matching_candidates(): void
+    {
+        $specialization = Specialization::factory()->create(['name' => 'City Tours']);
+
+        $trip = Trip::factory()
+            ->staffingWindow('2026-06-15', 3)
+            ->create([
+                'status' => 'staffing_in_progress',
+                'guide_specialization_ids' => [$specialization->id],
+                'requires_tour_leader' => true,
+                'driver_vehicle_type' => 'van',
+                'driver_vehicle_capacity' => 6,
+            ]);
+
+        $matchingGuide = \App\Models\Guide::factory()->matchingTrip($trip)->create();
+        \App\Models\Guide::factory()->nonMatchingSpecialization($trip)->create();
+        \App\Models\Guide::factory()->unavailableForTrip($trip)->create();
+        \App\Models\Guide::factory()->matchingTrip($trip)->recentlyAssigned(2)->create();
+
+        $matchingDriver = \App\Models\Driver::factory()->matchingTrip($trip)->create();
+        \App\Models\Driver::factory()->failingCapacity($trip)->create();
+        \App\Models\Driver::factory()->matchingTrip($trip)->failingLocation()->create();
+        \App\Models\Driver::factory()->unavailableForTrip($trip)->create();
+
+        ProcessTripGuideMatchingJob::dispatchSync($trip->id);
+        ProcessTripDriverMatchingJob::dispatchSync($trip->id);
+
+        $this->assertSame([$matchingGuide->id], $trip->fresh()->ranked_guide_ids);
+        $this->assertSame([$matchingDriver->id], $trip->fresh()->ranked_driver_ids);
+
+        $this->assertDatabaseHas('guide_requests', [
+            'trip_id' => $trip->id,
+            'guide_id' => $matchingGuide->id,
+            'status' => 'pending',
+            'chain_index' => 0,
+        ]);
+
+        $this->assertDatabaseHas('driver_requests', [
+            'trip_id' => $trip->id,
+            'driver_id' => $matchingDriver->id,
+            'status' => 'pending',
+            'chain_index' => 0,
+        ]);
+
+        $this->assertSame(1, GuideRequest::query()->where('trip_id', $trip->id)->count());
+        $this->assertSame(1, DriverRequest::query()->where('trip_id', $trip->id)->count());
+    }
+
+    public function test_partial_match_case_where_guides_match_but_drivers_fail(): void
+    {
+        $specialization = Specialization::factory()->create(['name' => 'Historical Tours']);
+
+        $trip = Trip::factory()
+            ->staffingWindow('2026-07-01', 2)
+            ->create([
+                'status' => 'staffing_in_progress',
+                'guide_specialization_ids' => [$specialization->id],
+                'requires_tour_leader' => false,
+                'driver_vehicle_type' => 'suv',
+                'driver_vehicle_capacity' => 8,
+            ]);
+
+        \App\Models\Guide::factory()->matchingTrip($trip)->create();
+        \App\Models\Driver::factory()->failingCapacity($trip)->create();
+        \App\Models\Driver::factory()->matchingTrip($trip)->failingLocation()->create();
+
+        ProcessTripGuideMatchingJob::dispatchSync($trip->id);
+        ProcessTripDriverMatchingJob::dispatchSync($trip->id);
+
+        $this->assertNotEmpty($trip->fresh()->ranked_guide_ids);
+        $this->assertSame([], $trip->fresh()->ranked_driver_ids ?? []);
+        $this->assertDatabaseCount('guide_requests', 1);
+        $this->assertDatabaseCount('driver_requests', 0);
+    }
+
+    public function test_conflict_case_excludes_unavailable_guides_and_drivers(): void
+    {
+        $specialization = Specialization::factory()->create(['name' => 'Nature Exploration']);
+
+        $trip = Trip::factory()->staffingWindow('2026-08-10', 4)->create([
+            'status' => 'staffing_in_progress',
+            'guide_specialization_ids' => [$specialization->id],
+            'requires_tour_leader' => false,
+            'driver_vehicle_type' => 'van',
+            'driver_vehicle_capacity' => 5,
+        ]);
+
+        $availableGuide = \App\Models\Guide::factory()->matchingTrip($trip)->create();
+        $conflictingGuide = \App\Models\Guide::factory()->unavailableForTrip($trip)->create();
+
+        $availableDriver = \App\Models\Driver::factory()->matchingTrip($trip)->create();
+        $conflictingDriver = \App\Models\Driver::factory()->unavailableForTrip($trip)->create();
+
+        $guideIds = app(GuideRankingService::class)->rankedGuideIdsForTrip($trip);
+        $driverIds = app(DriverRankingService::class)->rankedDriverIdsForTrip($trip);
+
+        $this->assertContains($availableGuide->id, $guideIds);
+        $this->assertNotContains($conflictingGuide->id, $guideIds);
+
+        $this->assertContains($availableDriver->id, $driverIds);
+        $this->assertNotContains($conflictingDriver->id, $driverIds);
+    }
+
+    public function test_ranking_case_orders_multiple_valid_candidates_by_score_rules(): void
+    {
+        $specialization = Specialization::factory()->create(['name' => 'Museum Tours']);
+
+        $trip = Trip::factory()->staffingWindow('2026-09-20', 2)->create([
+            'status' => 'staffing_in_progress',
+            'guide_specialization_ids' => [$specialization->id],
+            'requires_tour_leader' => false,
+            'driver_vehicle_type' => 'van',
+            'driver_vehicle_capacity' => 4,
+        ]);
+
+        $guideHigherPriority = \App\Models\Guide::factory()->matchingTrip($trip)->create([
+            'total_trips_count' => 1,
+            'last_trip_at' => now()->subDays(40),
+        ]);
+
+        $guideLowerPriority = \App\Models\Guide::factory()->matchingTrip($trip)->create([
+            'total_trips_count' => 4,
+            'last_trip_at' => now()->subDays(90),
+        ]);
+
+        $driverHigherPriority = \App\Models\Driver::factory()->matchingTrip($trip)->create([
+            'total_trips_count' => 1,
+            'last_trip_at' => now()->subDays(15),
+        ]);
+
+        $driverLowerPriority = \App\Models\Driver::factory()->matchingTrip($trip)->create([
+            'total_trips_count' => 3,
+            'last_trip_at' => now()->subDays(120),
+        ]);
+
+        $guideIds = app(GuideRankingService::class)->rankedGuideIdsForTrip($trip);
+        $driverIds = app(DriverRankingService::class)->rankedDriverIdsForTrip($trip);
+
+        $this->assertSame([$guideHigherPriority->id, $guideLowerPriority->id], $guideIds);
+        $this->assertSame([$driverHigherPriority->id, $driverLowerPriority->id], $driverIds);
+    }
+}


### PR DESCRIPTION
### Motivation
- Create deterministic, realistic factories for Trip staffing so matching, filtering, ranking and request sending can be tested reliably.
- Make trip schedules, trip days, transports, guide availabilities and assignments consistent so the staffing flow can generate conflicting and non-conflicting cases.

### Description
- Add a full `TripFactory` with deterministic defaults, automatic coherent schedules and `TripDay` creation, plus helpers `staffingWindow` and `withMultipleSchedules` to model multi-day and multi-schedule trips.
- Add `TripScheduleFactory`, `TripDayFactory`, `TripTransportFactory` and `GuideAvailabilityFactory` to provide linked data for transports and availability windows.
- Extend `GuideFactory` with staffing-focused states including `approved`/`accepted`, `tourLeader`, `matchingTrip`, `nonMatchingSpecialization`, `recentlyAssigned`, `rested`, `withSpecializations`, `locatedIn`, and `unavailableForTrip` which creates realistic assignment conflicts.
- Extend `DriverFactory` with staffing-focused states including `approved`/`accepted`, `locatedIn`, `withAssignment`, `matchingTrip`, `failingCapacity`, `failingLocation`, and `unavailableForTrip` which creates realistic vehicle/transport/reservation conflicts.
- Update `TripTransportFactory::withDriver` to accept a concrete `Driver` and create a deterministic `driver_id` state.
- Add `tests/Feature/TripStaffing/TripStaffingFactoryScenariosTest.php` covering four scenarios (perfect match, partial match, conflict exclusion, and ranking), and assertions that requests are only created for matched, available candidates.

### Testing
- Per-file PHP linting was run with `php -l` on the new/updated factories and the new test file and reported `No syntax errors detected` for all checked files.
- Attempted to run the feature test with `php artisan test tests/Feature/TripStaffing/TripStaffingFactoryScenariosTest.php` but the test run could not start in this environment because `vendor/autoload.php` is missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7b82a9a44832f88be85fe123fbd9e)