### PR TITLE
Show Complete Creating button for all draft trips

### DIFF
--- a/resources/views/trips/index.blade.php
+++ b/resources/views/trips/index.blade.php
@@ -80,7 +80,7 @@
                 <p class="text-gray-500 text-sm">Travelers: {{ $trip->max_participants ?? '-' }}</p>
                 <p class="text-gray-500 text-sm">Status: {{ ucfirst($trip->status) }}</p>
 
-                @if($trip->is_ai_generated && $trip->status === 'draft')
+                @if($trip->status === 'draft')
                     <a href="{{ route('trip.complete.edit', $trip->id) }}" class="inline-block mt-3 bg-yellow-500 hover:bg-yellow-600 text-white px-3 py-2 rounded">Complete Creating</a>
                 @endif
 


### PR DESCRIPTION
### Motivation
- Allow users to open the existing trip completion workspace for any trip that is in `draft` status (not just AI-generated trips) so manual trips can be finished using the same form prefilled from the database.

### Description
- Changed the conditional in `resources/views/trips/index.blade.php` to show the "Complete Creating" button for any trip with `status === 'draft'` instead of requiring `is_ai_generated`.
- The button still routes to the same completion workspace (`route('trip.complete.edit', $trip->id)`) so no route/controller changes were required.

### Testing
- Attempted to run `php artisan about` to validate the app, but it failed due to missing dependencies (`vendor/autoload.php`), so no runtime tests could be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7c22966c0832fb84f2c560e7aedf9)