### PR TITLE
Continue driver matching when guide chain is empty and centralize initial matching outcome

### DIFF
--- a/app/Jobs/TripStaffing/ProcessTripDriverMatchingJob.php
+++ b/app/Jobs/TripStaffing/ProcessTripDriverMatchingJob.php
@@ -31,13 +31,11 @@ class ProcessTripDriverMatchingJob implements ShouldQueue
         $rankedDriverIds = $rankingService->rankedDriverIdsForTrip($trip);
         $trip->update(['ranked_driver_ids' => $rankedDriverIds]);
 
-        if (empty($rankedDriverIds)) {
-            $coordinator->failTripStaffing($trip, 'No available drivers accepted requirements.');
-
-            return;
+        if (! empty($rankedDriverIds)) {
+            $handler = new SendToNextTripDriverHandler();
+            $handler->handle($trip, $rankedDriverIds, 0);
         }
 
-        $handler = new SendToNextTripDriverHandler();
-        $handler->handle($trip, $rankedDriverIds, 0);
+        $coordinator->finalizeInitialMatchingOutcome($trip);
     }
 }

--- a/app/Jobs/TripStaffing/ProcessTripGuideMatchingJob.php
+++ b/app/Jobs/TripStaffing/ProcessTripGuideMatchingJob.php
@@ -31,13 +31,11 @@ class ProcessTripGuideMatchingJob implements ShouldQueue
         $rankedGuideIds = $rankingService->rankedGuideIdsForTrip($trip);
         $trip->update(['ranked_guide_ids' => $rankedGuideIds]);
 
-        if (empty($rankedGuideIds)) {
-            $coordinator->failTripStaffing($trip, 'No available guides accepted requirements.');
-
-            return;
+        if (! empty($rankedGuideIds)) {
+            $handler = new SendToNextGuideHandler();
+            $handler->handle($trip, $rankedGuideIds, 0);
         }
 
-        $handler = new SendToNextGuideHandler();
-        $handler->handle($trip, $rankedGuideIds, 0);
+        $coordinator->finalizeInitialMatchingOutcome($trip);
     }
 }

--- a/app/Services/AiTrip/TripService.php
+++ b/app/Services/AiTrip/TripService.php
@@ -19,6 +19,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use LogicException;
 
 class TripService
 {
@@ -267,7 +268,19 @@ class TripService
                 'driver_road_type' => $payload['road_type'],
             ]);
 
-            $this->tripStateManager->transition($trip, 'ready_for_assignment');
+            $trip->refresh();
+
+            if ($trip->status === 'staffing_in_progress') {
+                $this->tripStateManager->transition($trip, 'draft');
+                $trip->refresh();
+            }
+
+            if ($trip->status === 'draft') {
+                $this->tripStateManager->transition($trip, 'ready_for_assignment');
+            } elseif ($trip->status !== 'ready_for_assignment') {
+                throw new LogicException("Cannot restart staffing from {$trip->status}.");
+            }
+
             StartTripStaffingJob::dispatch($trip->id)->afterCommit();
         });
     }

--- a/app/Services/TripStaffing/TripStaffingCoordinator.php
+++ b/app/Services/TripStaffing/TripStaffingCoordinator.php
@@ -92,6 +92,38 @@ class TripStaffingCoordinator
         $this->notifyAdmins("Trip #{$trip->id} reverted to draft: {$reason}");
     }
 
+    public function finalizeInitialMatchingOutcome(Trip $trip): void
+    {
+        $trip = $trip->fresh();
+
+        if (! $trip || $trip->status !== 'staffing_in_progress') {
+            return;
+        }
+
+        if ($trip->ranked_guide_ids === null || $trip->ranked_driver_ids === null) {
+            return;
+        }
+
+        $rankedGuideIds = $trip->ranked_guide_ids ?? [];
+        $rankedDriverIds = $trip->ranked_driver_ids ?? [];
+
+        if (empty($rankedGuideIds) && empty($rankedDriverIds)) {
+            $this->failTripStaffing($trip, 'No available guides or drivers accepted requirements.');
+
+            return;
+        }
+
+        if (empty($rankedGuideIds)) {
+            $this->failTripStaffing($trip, 'No available guides accepted requirements.');
+
+            return;
+        }
+
+        if (empty($rankedDriverIds)) {
+            $this->failTripStaffing($trip, 'No available drivers accepted requirements.');
+        }
+    }
+
     private function progressTripIfFullyStaffed(Trip $trip): void
     {
         if (! $trip->assigned_guide_id || ! $trip->assigned_driver_id) {

--- a/tests/Feature/TripStaffing/TripStaffingFactoryScenariosTest.php
+++ b/tests/Feature/TripStaffing/TripStaffingFactoryScenariosTest.php
@@ -108,6 +108,37 @@ class TripStaffingFactoryScenariosTest extends TestCase
         $this->assertDatabaseCount('driver_requests', 0);
     }
 
+
+    public function test_driver_chain_still_runs_when_guide_chain_has_no_candidates(): void
+    {
+        $trip = Trip::factory()
+            ->staffingWindow('2026-07-10', 2)
+            ->create([
+                'status' => 'staffing_in_progress',
+                'guide_specialization_ids' => [999999],
+                'requires_tour_leader' => false,
+                'driver_vehicle_type' => 'van',
+                'driver_vehicle_capacity' => 4,
+            ]);
+
+        $matchingDriver = \App\Models\Driver::factory()->matchingTrip($trip)->create();
+
+        ProcessTripGuideMatchingJob::dispatchSync($trip->id);
+        ProcessTripDriverMatchingJob::dispatchSync($trip->id);
+
+        $trip->refresh();
+
+        $this->assertSame([], $trip->ranked_guide_ids ?? []);
+        $this->assertSame([$matchingDriver->id], $trip->ranked_driver_ids ?? []);
+        $this->assertDatabaseCount('guide_requests', 0);
+        $this->assertDatabaseHas('driver_requests', [
+            'trip_id' => $trip->id,
+            'driver_id' => $matchingDriver->id,
+            'status' => 'pending',
+            'chain_index' => 0,
+        ]);
+    }
+
     public function test_conflict_case_excludes_unavailable_guides_and_drivers(): void
     {
         $specialization = Specialization::factory()->create(['name' => 'Nature Exploration']);


### PR DESCRIPTION
### Motivation

- Ensure the driver matching chain still executes when the guide matching chain produces no candidates, and centralize the logic that decides whether initial staffing should fail.
- Prevent duplicate handler invocation and make driver-saving logic safely restart staffing while enforcing valid state transitions.

### Description

- Update `ProcessTripDriverMatchingJob` and `ProcessTripGuideMatchingJob` to only invoke the respective `SendToNext*Handler` when there are ranked candidates and then call `TripStaffingCoordinator::finalizeInitialMatchingOutcome` after initial candidate processing.
- Add `TripStaffingCoordinator::finalizeInitialMatchingOutcome` to check both `ranked_guide_ids` and `ranked_driver_ids`, and call `failTripStaffing` with appropriate messages when no candidates exist for both or for a single role.
- Change `TripService::saveDrivers` to `refresh()` the `Trip`, transition a trip in `staffing_in_progress` back to `draft` before re-starting (`ready_for_assignment`), and throw a `LogicException` when the trip is in an unexpected state that cannot be used to restart staffing.
- Remove the prior early-fail behavior in matching jobs and the duplicate handler invocation so the coordinator centralizes the outcome decision.

### Testing

- Ran the trip-staffing feature scenarios file with `php artisan test --filter TripStaffingFactoryScenariosTest`, including the new `test_driver_chain_still_runs_when_guide_chain_has_no_candidates` test, and all tests in the file passed.
- Existing scenario `test_partial_match_case_where_guides_match_but_drivers_fail` was exercised and continues to pass under the updated flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7ffe9a5a4832faaab0f2acf187f1f)