### PR TITLE
Fix guide default to non-tour-leader and add ranking diagnostics

### DIFF
--- a/app/Services/AiTrip/TripService.php
+++ b/app/Services/AiTrip/TripService.php
@@ -254,7 +254,7 @@ class TripService
 
         $trip->update([
             'guide_specialization_ids' => $specializationIds,
-            'requires_tour_leader' => (bool) ($payload['requires_tour_leader'] ?? true),
+            'requires_tour_leader' => (bool) ($payload['requires_tour_leader'] ?? false),
         ]);
     }
 

--- a/app/Services/TripStaffing/DriverRankingService.php
+++ b/app/Services/TripStaffing/DriverRankingService.php
@@ -21,7 +21,7 @@ class DriverRankingService
         $start = optional($trip->schedules->min('start_date'));
         $end = optional($trip->schedules->max('end_date'));
 
-        $drivers = Driver::query()
+        $baseQuery = Driver::query()
             ->whereIn('status', ['approved', 'Approved'])
             ->whereHas('assignment', function ($assignmentQuery) use ($trip) {
                 $assignmentQuery->whereHas('vehicle', function ($vehicleQuery) use ($trip) {
@@ -44,7 +44,9 @@ class DriverRankingService
                         $locationQuery->orWhereRaw('LOWER(address) like ?', ["%{$country}%"]);
                     }
                 });
-            })
+            });
+
+        $drivers = (clone $baseQuery)
             ->with(['tripTransports.trip.schedules', 'reservations'])
             ->get()
             ->filter(function (Driver $driver) use ($start, $end) {
@@ -76,6 +78,19 @@ class DriverRankingService
                 return true;
             })
             ->values();
+
+        logger()->info('Trip driver ranking computed', [
+            'trip_id' => $trip->id,
+            'driver_vehicle_type' => $trip->driver_vehicle_type,
+            'driver_vehicle_capacity' => $trip->driver_vehicle_capacity,
+            'destination_city' => $city,
+            'destination_country' => $country,
+            'schedule_start' => $start,
+            'schedule_end' => $end,
+            'db_matched_count' => (clone $baseQuery)->count(),
+            'available_count' => $drivers->count(),
+            'available_driver_ids' => $drivers->pluck('id')->all(),
+        ]);
 
         if ($drivers->isEmpty()) {
             return [];

--- a/app/Services/TripStaffing/GuideRankingService.php
+++ b/app/Services/TripStaffing/GuideRankingService.php
@@ -22,7 +22,7 @@ class GuideRankingService
         $start = optional($trip->schedules->min('start_date'));
         $end = optional($trip->schedules->max('end_date'));
 
-        $guides = Guide::query()
+        $baseQuery = Guide::query()
             ->whereIn('status', ['approved', 'Approved'])
             ->when($trip->requires_tour_leader, fn ($query) => $query->where('is_tour_leader', true))
             ->when($specializationIds->isNotEmpty(), function ($query) use ($specializationIds) {
@@ -41,7 +41,9 @@ class GuideRankingService
             })
             ->where(function ($query) {
                 $query->whereNull('last_trip_at')->orWhere('last_trip_at', '<=', now()->subDays(6));
-            })
+            });
+
+        $guides = (clone $baseQuery)
             ->with(['assignments.trip.schedules'])
             ->get()
             ->filter(function (Guide $guide) use ($start, $end) {
@@ -64,6 +66,19 @@ class GuideRankingService
                 return true;
             })
             ->values();
+
+        logger()->info('Trip guide ranking computed', [
+            'trip_id' => $trip->id,
+            'requires_tour_leader' => (bool) $trip->requires_tour_leader,
+            'guide_specialization_ids' => $specializationIds->all(),
+            'destination_city' => $city,
+            'destination_country' => $country,
+            'schedule_start' => $start,
+            'schedule_end' => $end,
+            'db_matched_count' => (clone $baseQuery)->count(),
+            'available_count' => $guides->count(),
+            'available_guide_ids' => $guides->pluck('id')->all(),
+        ]);
 
         if ($guides->isEmpty()) {
             return [];


### PR DESCRIPTION
### Motivation
- The AI trip completion flow could omit `requires_tour_leader` in the payload which previously defaulted to `true` and accidentally filtered out most guides, causing empty `ranked_guide_ids` results. 
- Added structured diagnostics to make it easy to inspect why guides or drivers are not being matched by surfaceing DB matched counts, filters and final candidate IDs. 

### Description
- Change default behavior in `saveGuides()` so `requires_tour_leader` now defaults to `false` when the payload does not include that field (`app/Services/AiTrip/TripService.php`).
- Refactor guide and driver ranking code to build a reusable `baseQuery` before loading relations and applying availability filters in `GuideRankingService` and `DriverRankingService` (`app/Services/TripStaffing/GuideRankingService.php`, `app/Services/TripStaffing/DriverRankingService.php`).
- Add structured `logger()->info(...)` diagnostics in both ranking services that log trip filters, the DB matched candidate count, final available count, and the available candidate IDs. 
- The ranking and availability filtering logic was not changed beyond extracting the base query and emitting logs. 

### Testing
- Attempted to run `php artisan test tests/Feature/TripStaffing/TripStaffingFactoryScenariosTest.php` but the test run failed because `vendor/autoload.php` is missing in this environment (dependencies are not installed).
- No other automated tests were executed in this environment; changes are limited to query construction and logging and were sanity-checked by running static inspection and local file edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d807bd47fc832f9bb100ace26d6cd1)