### PR TITLE
Redirect AI trip edit flow to complete workspace

### DIFF
--- a/app/Http/Controllers/AiTripController.php
+++ b/app/Http/Controllers/AiTripController.php
@@ -66,23 +66,7 @@ class AiTripController extends Controller
                 ->with('error', 'This trip is already assigned to a guide and cannot be edited.');
         }
 
-        $destinations = Destination::query()->orderBy('name')->get(['id', 'name', 'city', 'country']);
-        $categories = Category::cases();
-        $formData = [
-            'destination_ids' => $trip->itineraryDestinations->pluck('id')->all() ?: [$trip->destination_id],
-            'description' => $trip->ai_prompt,
-            'max_participants' => $trip->max_participants,
-            'duration' => $trip->duration_days,
-            'budget' => optional($trip->packages->sortBy('price')->first())->price,
-            'categories' => collect(explode(',', (string) $trip->category))
-                ->map(fn ($value) => trim($value))
-                ->filter()
-                ->values()
-                ->all(),
-            'language' => 'en',
-        ];
-
-        return view('trips.ai.edit', compact('trip', 'destinations', 'categories', 'formData'));
+        return redirect()->route('trip.complete.edit', ['trip' => $trip, 'tab' => 'basics']);
     }
 
     public function update(AiTripUpdateRequest $request, Trip $trip)


### PR DESCRIPTION
### Motivation
- Editing AI-generated trips should use the same full "Complete AI Trip" interface so all trip fields (not only the create/form prompt fields) are editable in a consistent workspace.

### Description
- Changed `AiTripController::edit` to redirect to the completion workspace route `trip.complete.edit` with `tab=basics` instead of rendering the old AI edit/create form. 
- Preserved existing guards that abort for non-AI trips and block edits when `assigned_guide_id` is set.

### Testing
- Ran `php -l app/Http/Controllers/AiTripController.php` to validate syntax and it succeeded. 
- Verified the controller file was updated and committed (`git commit` completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e12d16da90832fbf8c9bde82fe9b4a)