### PR TITLE
Enforce reservation-scoped reviews, one-time review notifications, and update UI

### DIFF
--- a/app/Console/Commands/CheckReviewableCompletions.php
+++ b/app/Console/Commands/CheckReviewableCompletions.php
@@ -32,7 +32,7 @@ class CheckReviewableCompletions extends Command
     {
         $reservations = Reservation::where('reservation_status', 'paid')
             ->where('check_out_date', '<', now())
-            ->where('review_notified', false)
+            ->where('hotel_review_notification_sent', false)
             ->get();
             $this->info('Hotels found: ' . $reservations->count());
 
@@ -41,11 +41,12 @@ class CheckReviewableCompletions extends Command
             event(new ReviewableItemCompleted(
                 type: 'hotel',
                 id: $reservation->hotel_id,
-                userId: $reservation->user_id
+                userId: $reservation->user_id,
+                reservationId: $reservation->id
             ));
 
             $reservation->update([
-                'review_notified' => true
+                'hotel_review_notification_sent' => true
             ]);
         }
     }
@@ -55,33 +56,46 @@ class CheckReviewableCompletions extends Command
      */
     private function checkTrips()
     {
-        $reservations = TripReservation::where('status', 'completed')
+        $tripReservations = TripReservation::where('status', 'completed')
             ->whereHas('schedule', function ($q) {
                 $q->where('end_date', '<', now());
             })
-            ->where('review_notified', false)
+            ->where('trip_review_notification_sent', false)
             ->get();
     
-        foreach ($reservations as $reservation) {
+        foreach ($tripReservations as $reservation) {
     
-            // 1. Trip review
             event(new ReviewableItemCompleted(
                 type: 'trip',
                 id: $reservation->trip_id,
-                userId: $reservation->user_id
+                userId: $reservation->user_id,
+                reservationId: $reservation->id
             ));
     
-            // 2. Guide review 
-            if ($reservation->trip && $reservation->trip->assigned_guide_id) {
-                event(new ReviewableItemCompleted(
-                    type: 'guide',
-                    id: $reservation->trip->assigned_guide_id,
-                    userId: $reservation->user_id
-                ));
-            }
-    
             $reservation->update([
-                'review_notified' => true
+                'trip_review_notification_sent' => true
+            ]);
+        }
+
+        $guideReservations = TripReservation::where('status', 'completed')
+            ->whereHas('schedule', function ($q) {
+                $q->where('end_date', '<', now());
+            })
+            ->where('guide_review_notification_sent', false)
+            ->whereHas('trip', fn($q) => $q->whereNotNull('assigned_guide_id'))
+            ->with('trip:id,assigned_guide_id')
+            ->get();
+
+        foreach ($guideReservations as $reservation) {
+            event(new ReviewableItemCompleted(
+                type: 'guide',
+                id: $reservation->trip->assigned_guide_id,
+                userId: $reservation->user_id,
+                reservationId: $reservation->id
+            ));
+
+            $reservation->update([
+                'guide_review_notification_sent' => true,
             ]);
         }
     }
@@ -92,7 +106,7 @@ class CheckReviewableCompletions extends Command
     {
         $reservations = TransportReservation::where('status', 'completed')
             ->where('dropoff_datetime', '<', now())
-            ->where('review_notified', false)
+            ->where('driver_review_notification_sent', false)
             ->get();
 
         foreach ($reservations as $reservation) {
@@ -100,11 +114,12 @@ class CheckReviewableCompletions extends Command
             event(new ReviewableItemCompleted(
                 type: 'driver',
                 id: $reservation->driver_id,
-                userId: $reservation->user_id
+                userId: $reservation->user_id,
+                reservationId: $reservation->id
             ));
 
             $reservation->update([
-                'review_notified' => true
+                'driver_review_notification_sent' => true
             ]);
         }
     }

--- a/app/Events/ReviewableItemCompleted.php
+++ b/app/Events/ReviewableItemCompleted.php
@@ -20,7 +20,8 @@ class ReviewableItemCompleted
     public function __construct(
         public string $type,   // hotel, trip, driver, guide
         public int $id,
-        public int $userId
+        public int $userId,
+        public int $reservationId
     ) {}
 
     /**

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -3,13 +3,36 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use App\Models\TransportReservation;
+use App\Models\Review;
 
 class NotificationController extends Controller
 {
     public function index()
     {
         $notifications = auth()->user()->notifications()->latest()->paginate(20);
+
+        $reservationIds = $notifications->getCollection()
+            ->pluck('data.reservation_id')
+            ->filter()
+            ->unique()
+            ->values();
+
+        $reviewedReservationIds = Review::where('user_id', auth()->id())
+            ->whereIn('reservation_id', $reservationIds)
+            ->pluck('reservation_id')
+            ->map(fn($id) => (int) $id)
+            ->all();
+
+        $notifications->getCollection()->transform(function ($notification) use ($reviewedReservationIds) {
+            $reservationId = (int) data_get($notification->data, 'reservation_id');
+
+            if (($notification->data['type'] ?? null) === 'review_request') {
+                $notification->data['is_reviewed'] = in_array($reservationId, $reviewedReservationIds, true);
+            }
+
+            return $notification;
+        });
+
         return view('notifications.index', compact('notifications'));
     }
 
@@ -20,4 +43,3 @@ class NotificationController extends Controller
         return redirect()->back(); 
     }
 }
-

--- a/app/Http/Controllers/ReservationController.php
+++ b/app/Http/Controllers/ReservationController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use App\Http\Requests\ReservationRequest;
 use Illuminate\Support\Facades\Auth;
 use App\Models\Hotel;
+use App\Models\Review;
 use Carbon\Carbon;
 
 class ReservationController extends Controller
@@ -132,6 +133,12 @@ public function index(Request $request)
 
     $reservations = $query->latest()->get();
 
-    return view('reservation.index', compact('reservations'));
+    $reviewedReservationIds = Review::where('user_id', Auth::id())
+        ->whereIn('reservation_id', $reservations->pluck('id'))
+        ->pluck('reservation_id')
+        ->map(fn($id) => (int) $id)
+        ->all();
+
+    return view('reservation.index', compact('reservations', 'reviewedReservationIds'));
 }
 }

--- a/app/Http/Controllers/ReviewController.php
+++ b/app/Http/Controllers/ReviewController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\StoreReviewRequest;
 use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use Illuminate\Database\QueryException;
 
 use App\Services\Review\ReviewFactoryService;
 use App\Services\Review\ReviewEligibilityService;
@@ -23,7 +25,8 @@ class ReviewController extends Controller
 {
     return view('reviews.create', [
         'type' => $request->type,
-        'id' => $request->id
+        'id' => $request->id,
+        'reservationId' => $request->reservation_id,
     ]);
 }
 
@@ -32,7 +35,8 @@ class ReviewController extends Controller
      */
     public function store(
         StoreReviewRequest $request,
-        ReviewFactoryService $factory
+        ReviewFactoryService $factory,
+        ReviewEligibilityService $eligibilityService
     ) {
         
     
@@ -42,8 +46,39 @@ class ReviewController extends Controller
             'driver' => Driver::findOrFail($request->id),
             'guide' => Guide::findOrFail($request->id),
         };
-    
-        $factory->create($model, $request->only('rating', 'review'));
+
+        $reservation = $eligibilityService->resolveOwnedReservation(
+            $request->user(),
+            $request->type,
+            (int) $request->id,
+            (int) $request->reservation_id
+        );
+
+        if (! $reservation) {
+            abort(403, 'Unauthorized reservation access.');
+        }
+
+        $alreadyReviewed = Review::where('user_id', $request->user()->id)
+            ->where('reservation_id', $request->reservation_id)
+            ->exists();
+
+        if ($alreadyReviewed) {
+            throw ValidationException::withMessages([
+                'reservation_id' => 'You have already submitted a review for this reservation.',
+            ]);
+        }
+
+        try {
+            $factory->create($model, $request->only('rating', 'review', 'reservation_id'));
+        } catch (QueryException $e) {
+            if ((string) $e->getCode() === '23000') {
+                throw ValidationException::withMessages([
+                    'reservation_id' => 'You have already submitted a review for this reservation.',
+                ]);
+            }
+
+            throw $e;
+        }
     
         return redirect()->back()->with('success', 'Thanks for your review ❤️');
     }

--- a/app/Http/Controllers/TransportReservationController.php
+++ b/app/Http/Controllers/TransportReservationController.php
@@ -10,6 +10,7 @@ use App\Services\GeocodingService;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use App\Services\TransportReservation\ReservationStateManager;
+use App\Models\Review;
 
 class TransportReservationController extends Controller
 {
@@ -132,7 +133,13 @@ class TransportReservationController extends Controller
             ->orderBy('pickup_datetime', 'desc')
             ->paginate(10);
 
-        return view('transportreservation.index', compact('reservations'));
+        $reviewedReservationIds = Review::where('user_id', Auth::id())
+            ->whereIn('reservation_id', $reservations->getCollection()->pluck('id'))
+            ->pluck('reservation_id')
+            ->map(fn($id) => (int) $id)
+            ->all();
+
+        return view('transportreservation.index', compact('reservations', 'reviewedReservationIds'));
     }
 
     /**

--- a/app/Http/Controllers/TripBookingController.php
+++ b/app/Http/Controllers/TripBookingController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\Models\TripPackage;
 use App\Models\TripSchedule;
 use App\Models\TripReservation;
+use App\Models\Review;
 
 class TripBookingController extends Controller
 {
@@ -83,7 +84,13 @@ public function index(Request $request)
 
     $reservations = $query->latest()->get();
 
-    return view('trips.reservations.index', compact('reservations'));
+    $reviewedReservationIds = Review::where('user_id', auth()->id())
+        ->whereIn('reservation_id', $reservations->pluck('id'))
+        ->pluck('reservation_id')
+        ->map(fn($id) => (int) $id)
+        ->all();
+
+    return view('trips.reservations.index', compact('reservations', 'reviewedReservationIds'));
 }
 
 }

--- a/app/Http/Requests/StoreReviewRequest.php
+++ b/app/Http/Requests/StoreReviewRequest.php
@@ -2,18 +2,23 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreReviewRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        $user = auth()->user();
-    
-        if (!$user) {
-            return false;
-        }
-    
-        return app(\App\Services\Review\ReviewEligibilityService::class)
-            ->canReview($user, $this->type, $this->id);
+        return auth()->check();
+    }
+
+    public function rules(): array
+    {
+        return [
+            'type' => ['required', 'string', Rule::in(['hotel', 'trip', 'guide', 'driver'])],
+            'id' => ['required', 'integer', 'min:1'],
+            'reservation_id' => ['required', 'integer', 'min:1'],
+            'rating' => ['required', 'integer', 'min:1', 'max:5'],
+            'review' => ['nullable', 'string'],
+        ];
     }
 }

--- a/app/Listeners/SendReviewRequestNotification.php
+++ b/app/Listeners/SendReviewRequestNotification.php
@@ -19,6 +19,7 @@ class SendReviewRequestNotification
             new ReviewRequestNotification(
                 type: $event->type,
                 itemId: $event->id,
+                reservationId: $event->reservationId,
                 itemName: $this->getItemName($event->type, $event->id)
             )
         );

--- a/app/Models/Reservation.php
+++ b/app/Models/Reservation.php
@@ -20,6 +20,7 @@ class Reservation extends Model
         'guest_count',
         'total_price',
         'reservation_status',
+        'hotel_review_notification_sent',
     ];
 
     protected $hidden = [

--- a/app/Models/Review.php
+++ b/app/Models/Review.php
@@ -13,8 +13,11 @@ class Review extends Model
 
     protected $fillable = [
         'user_id',
+        'reviewable_type',
+        'reviewable_id',
         'rating',
         'review',
+        'reservation_id',
         'is_hidden_by_admin',
     ];
 

--- a/app/Models/TransportReservation.php
+++ b/app/Models/TransportReservation.php
@@ -24,6 +24,7 @@ class TransportReservation extends Model
         'driver_id',
         'driver_status',
         'ranked_driver_ids',
+        'driver_review_notification_sent',
         
 
     ];

--- a/app/Models/TripReservation.php
+++ b/app/Models/TripReservation.php
@@ -19,6 +19,8 @@ class TripReservation extends Model
         'guide_earning',
         'guide_id',
         'guide_paid_at',
+        'trip_review_notification_sent',
+        'guide_review_notification_sent',
     ];
 
         public function guide()

--- a/app/Notifications/ReviewRequestNotification.php
+++ b/app/Notifications/ReviewRequestNotification.php
@@ -12,6 +12,7 @@ class ReviewRequestNotification extends Notification
     public function __construct(
         public string $type,
         public int $itemId,
+        public int $reservationId,
         public string $itemName,
         public string $message = 'Please rate your experience'
     ) {}
@@ -27,6 +28,7 @@ class ReviewRequestNotification extends Notification
             'type' => 'review_request',
             'review_type' => $this->type,
             'review_id' => $this->itemId,
+            'reservation_id' => $this->reservationId,
             'review_name' => $this->itemName,
             'message' => $this->message,
         ];

--- a/app/Services/Review/ReviewEligibilityService.php
+++ b/app/Services/Review/ReviewEligibilityService.php
@@ -5,12 +5,17 @@ use App\Models\User;
 use App\Models\Reservation;
 use App\Models\TripReservation;
 use App\Models\TransportReservation;
+use Illuminate\Database\Eloquent\Model;
 
 
 class ReviewEligibilityService
 {
-    public function canReview(User $user, string $type, int $id): bool
+    public function canReview(User $user, string $type, int $id, ?int $reservationId = null): bool
     {
+        if ($reservationId !== null) {
+            return $this->resolveOwnedReservation($user, $type, $id, $reservationId) !== null;
+        }
+
         return match ($type) {
 
             'hotel' => Reservation::where('user_id', $user->id)
@@ -44,6 +49,41 @@ class ReviewEligibilityService
                 ->exists(),
 
             default => false,
+        };
+    }
+
+    public function resolveOwnedReservation(User $user, string $type, int $reviewableId, int $reservationId): ?Model
+    {
+        return match ($type) {
+            'hotel' => Reservation::whereKey($reservationId)
+                ->where('user_id', $user->id)
+                ->where('hotel_id', $reviewableId)
+                ->where('reservation_status', 'paid')
+                ->where('check_out_date', '<', now())
+                ->first(),
+
+            'trip' => TripReservation::whereKey($reservationId)
+                ->where('user_id', $user->id)
+                ->where('trip_id', $reviewableId)
+                ->where('status', 'completed')
+                ->whereHas('schedule', fn($q) => $q->where('end_date', '<', now()))
+                ->first(),
+
+            'driver' => TransportReservation::whereKey($reservationId)
+                ->where('user_id', $user->id)
+                ->where('driver_id', $reviewableId)
+                ->where('status', 'completed')
+                ->where('dropoff_datetime', '<', now())
+                ->first(),
+
+            'guide' => TripReservation::whereKey($reservationId)
+                ->where('user_id', $user->id)
+                ->where('status', 'completed')
+                ->whereHas('trip', fn($q) => $q->where('assigned_guide_id', $reviewableId))
+                ->whereHas('schedule', fn($q) => $q->where('end_date', '<', now()))
+                ->first(),
+
+            default => null,
         };
     }
 }

--- a/app/Services/Review/ReviewFactoryService.php
+++ b/app/Services/Review/ReviewFactoryService.php
@@ -11,6 +11,7 @@ class ReviewFactoryService
             'user_id' => auth()->id(),
             'rating' => $data['rating'],
             'review' => $data['review'] ?? null,
+            'reservation_id' => $data['reservation_id'],
         ]);
     }
 }

--- a/database/migrations/2026_04_18_000001_add_reservation_id_and_unique_to_reviews_table.php
+++ b/database/migrations/2026_04_18_000001_add_reservation_id_and_unique_to_reviews_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reviews', function (Blueprint $table) {
+            if (! Schema::hasColumn('reviews', 'reservation_id')) {
+                $table->unsignedBigInteger('reservation_id')->after('reviewable_id');
+            }
+
+            $table->unique(['user_id', 'reservation_id'], 'reviews_user_reservation_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reviews', function (Blueprint $table) {
+            $table->dropUnique('reviews_user_reservation_unique');
+
+            if (Schema::hasColumn('reviews', 'reservation_id')) {
+                $table->dropColumn('reservation_id');
+            }
+        });
+    }
+};

--- a/database/migrations/2026_04_18_000002_add_review_notification_flags_to_reservation_tables.php
+++ b/database/migrations/2026_04_18_000002_add_review_notification_flags_to_reservation_tables.php
@@ -1,0 +1,82 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reservations', function (Blueprint $table) {
+            if (! Schema::hasColumn('reservations', 'hotel_review_notification_sent')) {
+                $table->boolean('hotel_review_notification_sent')->default(false)->after('reservation_status');
+            }
+
+            if (Schema::hasColumn('reservations', 'review_notified')) {
+                $table->dropColumn('review_notified');
+            }
+        });
+
+        Schema::table('trip_reservations', function (Blueprint $table) {
+            if (! Schema::hasColumn('trip_reservations', 'trip_review_notification_sent')) {
+                $table->boolean('trip_review_notification_sent')->default(false)->after('status');
+            }
+
+            if (! Schema::hasColumn('trip_reservations', 'guide_review_notification_sent')) {
+                $table->boolean('guide_review_notification_sent')->default(false)->after('trip_review_notification_sent');
+            }
+
+            if (Schema::hasColumn('trip_reservations', 'review_notified')) {
+                $table->dropColumn('review_notified');
+            }
+        });
+
+        Schema::table('transport_reservations', function (Blueprint $table) {
+            if (! Schema::hasColumn('transport_reservations', 'driver_review_notification_sent')) {
+                $table->boolean('driver_review_notification_sent')->default(false)->after('status');
+            }
+
+            if (Schema::hasColumn('transport_reservations', 'review_notified')) {
+                $table->dropColumn('review_notified');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reservations', function (Blueprint $table) {
+            if (Schema::hasColumn('reservations', 'hotel_review_notification_sent')) {
+                $table->dropColumn('hotel_review_notification_sent');
+            }
+
+            if (! Schema::hasColumn('reservations', 'review_notified')) {
+                $table->boolean('review_notified')->default(false);
+            }
+        });
+
+        Schema::table('trip_reservations', function (Blueprint $table) {
+            if (Schema::hasColumn('trip_reservations', 'trip_review_notification_sent')) {
+                $table->dropColumn('trip_review_notification_sent');
+            }
+
+            if (Schema::hasColumn('trip_reservations', 'guide_review_notification_sent')) {
+                $table->dropColumn('guide_review_notification_sent');
+            }
+
+            if (! Schema::hasColumn('trip_reservations', 'review_notified')) {
+                $table->boolean('review_notified')->default(false);
+            }
+        });
+
+        Schema::table('transport_reservations', function (Blueprint $table) {
+            if (Schema::hasColumn('transport_reservations', 'driver_review_notification_sent')) {
+                $table->dropColumn('driver_review_notification_sent');
+            }
+
+            if (! Schema::hasColumn('transport_reservations', 'review_notified')) {
+                $table->boolean('review_notified')->default(false);
+            }
+        });
+    }
+};

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -90,14 +90,25 @@
                                 {{ $data['review_name'] ?? 'this item' }}
                             </span>
                         </p>
-                
-                        <a href="{{ route('reviews.create', [
-                            'type' => $data['review_type'],
-                            'id' => $data['review_id']
-                        ]) }}"
-                           class="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700">
-                            Rate Now
-                        </a>
+
+                        @if(($data['is_reviewed'] ?? false) === true)
+                            <button
+                                type="button"
+                                disabled
+                                class="bg-gray-300 text-gray-700 px-4 py-2 rounded-lg cursor-not-allowed"
+                            >
+                                Rated
+                            </button>
+                        @else
+                            <a href="{{ route('reviews.create', [
+                                'type' => $data['review_type'],
+                                'id' => $data['review_id'],
+                                'reservation_id' => $data['reservation_id']
+                            ]) }}"
+                            class="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700">
+                                Rate Now
+                            </a>
+                        @endif
                     </div>
 
 

--- a/resources/views/reservation/index.blade.php
+++ b/resources/views/reservation/index.blade.php
@@ -114,6 +114,9 @@
                         <th class="p-3 border">Guests</th>
                         <th class="p-3 border">Total Price</th>
                         <th class="p-3 border">Status</th>
+                        @if(Auth::user()->role !== 'admin')
+                            <th class="p-3 border">Hotel Review</th>
+                        @endif
                     </tr>
                 </thead>
 
@@ -147,6 +150,21 @@
                                     {{ ucfirst($reservation->reservation_status) }}
                                 </span>
                             </td>
+
+                            @if(Auth::user()->role !== 'admin')
+                                <td class="p-3 border">
+                                    @if(in_array((int) $reservation->id, $reviewedReservationIds ?? [], true))
+                                        <button type="button" disabled class="px-3 py-1 rounded bg-gray-300 text-gray-700 cursor-not-allowed">
+                                            Rated
+                                        </button>
+                                    @else
+                                        <a href="{{ route('reviews.create', ['type' => 'hotel', 'id' => $reservation->hotel_id, 'reservation_id' => $reservation->id]) }}"
+                                            class="px-3 py-1 rounded bg-indigo-600 text-white hover:bg-indigo-700">
+                                            Rate Now
+                                        </a>
+                                    @endif
+                                </td>
+                            @endif
 
                         </tr>
                     @endforeach

--- a/resources/views/reviews/create.blade.php
+++ b/resources/views/reviews/create.blade.php
@@ -115,11 +115,22 @@
                 </div>
             @endif
 
+            @if($errors->any())
+                <div class="mb-4 p-3 bg-red-100 text-red-800 rounded">
+                    <ul class="list-disc list-inside">
+                        @foreach($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+
             <form method="POST" action="{{ route('reviews.store') }}">
                 @csrf
 
                 <input type="hidden" name="type" value="{{ $type }}">
                 <input type="hidden" name="id" value="{{ $id }}">
+                <input type="hidden" name="reservation_id" value="{{ $reservationId }}">
 
                 {{-- STARS --}}
                 <div class="mb-4 text-center">

--- a/resources/views/transportreservation/index.blade.php
+++ b/resources/views/transportreservation/index.blade.php
@@ -78,6 +78,9 @@ class="mb-6  p-4 rounded-xl shadow flex flex-wrap gap-4 items-end">
                     <th class="p-3 border">Pickup Date</th>
                     <th class="p-3 border">Passengers</th>
                     <th class="p-3 border">Total Price</th>
+                    @if(Auth::user()->role !== 'admin')
+                        <th class="p-3 border">Driver Review</th>
+                    @endif
              
                 </tr>
             </thead>
@@ -104,11 +107,26 @@ class="mb-6  p-4 rounded-xl shadow flex flex-wrap gap-4 items-end">
                         <td class="p-3 border text-green-600 font-semibold">
                             ${{ number_format($reservation->total_price, 2) }}
                         </td>
+
+                        @if(Auth::user()->role !== 'admin')
+                            <td class="p-3 border">
+                                @if(in_array((int) $reservation->id, $reviewedReservationIds ?? [], true))
+                                    <button type="button" disabled class="px-3 py-1 rounded bg-gray-300 text-gray-700 cursor-not-allowed">
+                                        Rated
+                                    </button>
+                                @else
+                                    <a href="{{ route('reviews.create', ['type' => 'driver', 'id' => $reservation->driver_id, 'reservation_id' => $reservation->id]) }}"
+                                       class="px-3 py-1 rounded bg-indigo-600 text-white hover:bg-indigo-700">
+                                        Rate Now
+                                    </a>
+                                @endif
+                            </td>
+                        @endif
                         
                     </tr>
                 @empty
                     <tr>
-                        <td colspan="7" class="p-4 text-center text-gray-500">
+                        <td colspan="{{ Auth::user()->role === 'admin' ? 6 : 7 }}" class="p-4 text-center text-gray-500">
                             No transport reservations found.
                         </td>
                     </tr>

--- a/resources/views/trips/reservations/index.blade.php
+++ b/resources/views/trips/reservations/index.blade.php
@@ -79,6 +79,10 @@
                     <th class="p-3 border">People</th>
                     <th class="p-3 border">Total Price</th>
                     <th class="p-3 border">Status</th>
+                    @if(Auth::user()->role !== 'admin')
+                        <th class="p-3 border">Trip Review</th>
+                        <th class="p-3 border">Guide Review</th>
+                    @endif
                 </tr>
             </thead>
     
@@ -119,11 +123,42 @@
                                 {{ ucfirst($r->status) }}
                             </span>
                         </td>
+
+                        @if(Auth::user()->role !== 'admin')
+                            <td class="p-3 border">
+                                @if(in_array((int) $r->id, $reviewedReservationIds ?? [], true))
+                                    <button type="button" disabled class="px-3 py-1 rounded bg-gray-300 text-gray-700 cursor-not-allowed">
+                                        Rated
+                                    </button>
+                                @else
+                                    <a href="{{ route('reviews.create', ['type' => 'trip', 'id' => $r->trip_id, 'reservation_id' => $r->id]) }}"
+                                       class="px-3 py-1 rounded bg-indigo-600 text-white hover:bg-indigo-700">
+                                        Rate Now
+                                    </a>
+                                @endif
+                            </td>
+
+                            <td class="p-3 border">
+                                @php($guideId = $r->trip?->assigned_guide_id)
+                                @if(!$guideId)
+                                    <span class="text-gray-500">N/A</span>
+                                @elseif(in_array((int) $r->id, $reviewedReservationIds ?? [], true))
+                                    <button type="button" disabled class="px-3 py-1 rounded bg-gray-300 text-gray-700 cursor-not-allowed">
+                                        Rated
+                                    </button>
+                                @else
+                                    <a href="{{ route('reviews.create', ['type' => 'guide', 'id' => $guideId, 'reservation_id' => $r->id]) }}"
+                                       class="px-3 py-1 rounded bg-indigo-600 text-white hover:bg-indigo-700">
+                                        Rate Now
+                                    </a>
+                                @endif
+                            </td>
+                        @endif
     
                     </tr>
                 @empty
                     <tr>
-                        <td colspan="7" class="p-4 text-center text-gray-500">
+                        <td colspan="{{ Auth::user()->role === 'admin' ? 7 : 9 }}" class="p-4 text-center text-gray-500">
                             No trip reservations found.
                         </td>
                     </tr>


### PR DESCRIPTION
### Motivation
- Stop incorrect 403s and wrong duplicate blocking by authorizing reviews by reservation ownership and prevent duplicates by reservation, not by item id. 
- Ensure review notifications are sent exactly once per reservation and separately for hotel/trip/guide/driver paths. 
- Surface correct Rate Now / Rated UI states per reservation so users see actionable review links only when appropriate.

### Description
- Review submission: `StoreReviewRequest` now validates `type`, `id`, `reservation_id`, `rating` and `review`, and `ReviewController::store` authorizes by resolving the owned reservation via `ReviewEligibilityService::resolveOwnedReservation` before creating a review; returns `403` only when reservation ownership/eligibility fails and returns a validation error when the same `(user_id, reservation_id)` is already reviewed. 
- Duplicate prevention and persistence: `ReviewFactoryService` now persists `reservation_id` and `Review` model `fillable` updated; added migration `2026_04_18_000001_add_reservation_id_and_unique_to_reviews_table.php` which adds `reservation_id` to `reviews` and a unique index on `user_id, reservation_id`. 
- Notifications/event flow: the `ReviewableItemCompleted` event and `ReviewRequestNotification` now carry `reservation_id`; listener `SendReviewRequestNotification` includes it in the notification payload. 
- Scheduler/flags: refactored `reviews:check-completions` to send per-type notifications once and set new flags instead of a shared flag (`hotel_review_notification_sent`, `trip_review_notification_sent`, `guide_review_notification_sent`, `driver_review_notification_sent`), and added migration `2026_04_18_000002_add_review_notification_flags_to_reservation_tables.php` to add/remove these flags. 
- UI and controller updates: notification and reservation listing controllers annotate notifications/reservations with reviewed reservation IDs and Blade views (`resources/views/notifications/index.blade.php`, `resources/views/reviews/create.blade.php`, `resources/views/reservation/index.blade.php`, `resources/views/trips/reservations/index.blade.php`, `resources/views/transportreservation/index.blade.php`) show either a disabled "Rated" button or a reservation-scoped "Rate Now" link that passes `reservation_id`. 
- Model/support changes: updated `Reservation`, `TripReservation`, and `TransportReservation` fillables to include the new notification flags; `ReviewEligibilityService` extended with `resolveOwnedReservation` and optional reservation-based check.

### Testing
- Ran PHP syntax checks (`php -l`) on modified backend files (controller, service, command, request, event, notification) and they passed with no syntax errors. 
- Attempted to run the test suite (`php artisan test --filter=Review --stop-on-failure`) but it failed to run in this environment because Composer dependencies were not installed (`vendor/autoload.php` missing); no feature/unit tests were executed here. 
- Created and committed the changes (includes two new migrations) and verified updated files for static correctness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4037c1ca8832fbc978f45478b518c)