### PR TITLE
Add Groq-powered AI assistants for hotels, destinations, activities, and trips

### DIFF
--- a/app/Http/Controllers/AiAssistantController.php
+++ b/app/Http/Controllers/AiAssistantController.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Activity;
+use App\Models\Destination;
+use App\Models\Hotel;
+use App\Models\Trip;
+use App\Services\AiAssistant\GroqEntityAssistantService;
+use App\Services\AiAssistant\Prompts\ActivityPromptService;
+use App\Services\AiAssistant\Prompts\DestinationPromptService;
+use App\Services\AiAssistant\Prompts\HotelPromptService;
+use App\Services\AiAssistant\Prompts\TripPromptService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class AiAssistantController extends Controller
+{
+    public function __construct(
+        protected GroqEntityAssistantService $groqService,
+        protected HotelPromptService $hotelPromptService,
+        protected DestinationPromptService $destinationPromptService,
+        protected ActivityPromptService $activityPromptService,
+        protected TripPromptService $tripPromptService,
+    ) {
+    }
+
+    public function askHotel(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'entity_id' => ['required', 'integer', 'exists:hotels,id'],
+            'question' => ['required', 'string', 'max:1000'],
+        ]);
+
+        $hotel = Hotel::query()->with('destination')->findOrFail($data['entity_id']);
+
+        return $this->respond(
+            $this->hotelPromptService->systemMessage(),
+            $this->hotelPromptService->userMessage($hotel, $data['question'])
+        );
+    }
+
+    public function askDestination(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'entity_id' => ['required', 'integer', 'exists:destinations,id'],
+            'question' => ['required', 'string', 'max:1000'],
+        ]);
+
+        $destination = Destination::query()
+            ->with('highlights:id,destination_id,title')
+            ->findOrFail($data['entity_id']);
+
+        return $this->respond(
+            $this->destinationPromptService->systemMessage(),
+            $this->destinationPromptService->userMessage($destination, $data['question'])
+        );
+    }
+
+    public function askActivity(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'entity_id' => ['required', 'integer', 'exists:activities,id'],
+            'question' => ['required', 'string', 'max:1000'],
+        ]);
+
+        $activity = Activity::query()
+            ->with(['destination', 'highlights:id,activity_id,title'])
+            ->findOrFail($data['entity_id']);
+
+        return $this->respond(
+            $this->activityPromptService->systemMessage(),
+            $this->activityPromptService->userMessage($activity, $data['question'])
+        );
+    }
+
+    public function askTrip(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'entity_id' => ['required', 'integer', 'exists:trips,id'],
+            'question' => ['required', 'string', 'max:1000'],
+        ]);
+
+        $trip = Trip::query()
+            ->with([
+                'itineraryDestinations:id,name',
+                'packages:id,trip_id,name,price',
+            ])
+            ->findOrFail($data['entity_id']);
+
+        return $this->respond(
+            $this->tripPromptService->systemMessage(),
+            $this->tripPromptService->userMessage($trip, $data['question'])
+        );
+    }
+
+    protected function respond(string $systemMessage, string $userMessage): JsonResponse
+    {
+        $answer = $this->groqService->ask($systemMessage, $userMessage);
+
+        if (blank($answer)) {
+            return response()->json([
+                'answer' => 'I couldn\'t generate an answer right now. Please try again in a moment, or ask your question in a different way.',
+            ], 503);
+        }
+
+        return response()->json([
+            'answer' => $answer,
+        ]);
+    }
+}

--- a/app/Services/AiAssistant/GroqEntityAssistantService.php
+++ b/app/Services/AiAssistant/GroqEntityAssistantService.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Services\AiAssistant;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class GroqEntityAssistantService
+{
+    protected string $endpoint = 'https://api.groq.com/openai/v1/chat/completions';
+    protected string $model = 'llama-3.3-70b-versatile';
+    protected string $apiKey;
+
+    public function __construct()
+    {
+        $this->apiKey = (string) env('GROQ_API_KEY', '');
+    }
+
+    public function ask(string $systemMessage, string $userMessage): ?string
+    {
+        if (blank($this->apiKey)) {
+            Log::error('Groq API Key is missing for entity assistant.');
+            return null;
+        }
+
+        try {
+            $response = Http::withHeaders([
+                'Authorization' => 'Bearer '.$this->apiKey,
+                'Content-Type' => 'application/json',
+            ])->post($this->endpoint, [
+                'model' => $this->model,
+                'messages' => [
+                    ['role' => 'system', 'content' => $systemMessage],
+                    ['role' => 'user', 'content' => $userMessage],
+                ],
+                'temperature' => 0.4,
+                'max_tokens' => 900,
+            ]);
+
+            if (! $response->successful()) {
+                Log::error('Groq entity assistant request failed', [
+                    'status' => $response->status(),
+                    'body' => $response->body(),
+                ]);
+
+                return null;
+            }
+
+            $content = $response->json('choices.0.message.content');
+
+            if (! is_string($content) || blank($content)) {
+                return null;
+            }
+
+            return trim($content);
+        } catch (\Throwable $e) {
+            Log::error('Groq entity assistant exception', ['message' => $e->getMessage()]);
+
+            return null;
+        }
+    }
+}

--- a/app/Services/AiAssistant/Prompts/ActivityPromptService.php
+++ b/app/Services/AiAssistant/Prompts/ActivityPromptService.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Services\AiAssistant\Prompts;
+
+use App\Models\Activity;
+
+class ActivityPromptService
+{
+    public function systemMessage(): string
+    {
+        return 'You are an activity planning assistant. Explain timing, preparation, difficulty, safety, and suitability clearly. Be honest about unknowns. Do not output JSON.';
+    }
+
+    public function userMessage(Activity $activity, string $question): string
+    {
+        $amenities = collect($activity->amenities ?? [])->filter()->implode(', ');
+        $highlights = $activity->highlights->pluck('title')->filter()->implode(', ');
+
+        return "Activity profile:\n"
+            ."- Name: {$activity->name}\n"
+            ."- Destination: ".optional($activity->destination)->name."\n"
+            ."- Category: ".($activity->category ?? 'N/A')."\n"
+            ."- Description: ".($activity->description ?? 'N/A')."\n"
+            ."- Duration: ".($activity->duration ?? 'N/A').' '.($activity->duration_unit ?? '')."\n"
+            ."- Price: ".($activity->price ?? 'N/A')."\n"
+            ."- Difficulty level: ".($activity->difficulty_level ?? 'N/A')."\n"
+            ."- Requirements: ".($activity->requirements ?? 'N/A')."\n"
+            ."- Amenities: ".($amenities ?: 'N/A')."\n"
+            ."- Highlights: ".($highlights ?: 'N/A')."\n"
+            ."- Family friendly: ".($activity->family_friendly ? 'Yes' : 'No')."\n"
+            ."- Pets allowed: ".($activity->pets_allowed ? 'Yes' : 'No')."\n"
+            ."- Requires booking: ".($activity->requires_booking ? 'Yes' : 'No')."\n\n"
+            ."User question: {$question}\n\n"
+            .'Respond with practical recommendations and brief preparation checklist when useful.';
+    }
+}

--- a/app/Services/AiAssistant/Prompts/DestinationPromptService.php
+++ b/app/Services/AiAssistant/Prompts/DestinationPromptService.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Services\AiAssistant\Prompts;
+
+use App\Models\Destination;
+
+class DestinationPromptService
+{
+    public function systemMessage(): string
+    {
+        return 'You are a destination travel advisor. Give insightful itineraries, practical tips, safety, culture, and budget guidance using only supplied context plus common travel best practices. No JSON output.';
+    }
+
+    public function userMessage(Destination $destination, string $question): string
+    {
+        $highlights = $destination->highlights->pluck('title')->filter()->take(10)->implode(', ');
+
+        return "Destination profile:\n"
+            ."- Name: {$destination->name}\n"
+            ."- City/Country: {$destination->city}, {$destination->country}\n"
+            ."- Description: ".($destination->description ?? 'N/A')."\n"
+            ."- Best time to visit: ".($destination->best_time_to_visit ?? 'N/A')."\n"
+            ."- Language: ".($destination->language ?? 'N/A')."\n"
+            ."- Currency: ".($destination->currency ?? 'N/A')."\n"
+            ."- Nearest airport: ".($destination->nearest_airport ?? 'N/A')."\n"
+            ."- Emergency numbers: ".($destination->emergency_numbers ?? 'N/A')."\n"
+            ."- Local tip: ".($destination->local_tip ?? 'N/A')."\n"
+            ."- Known highlights: ".($highlights ?: 'N/A')."\n\n"
+            ."User question: {$question}\n\n"
+            .'Give a tailored answer with short sections when helpful (e.g., what to do, planning logic, cautions, money-saving moves).';
+    }
+}

--- a/app/Services/AiAssistant/Prompts/HotelPromptService.php
+++ b/app/Services/AiAssistant/Prompts/HotelPromptService.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services\AiAssistant\Prompts;
+
+use App\Models\Hotel;
+
+class HotelPromptService
+{
+    public function systemMessage(): string
+    {
+        return 'You are a hotel travel advisor. Give practical, analytical, and personalized advice. Do not output JSON. Do not invent facts beyond provided data. If data is missing, acknowledge it and provide a reasonable general recommendation.';
+    }
+
+    public function userMessage(Hotel $hotel, string $question): string
+    {
+        $amenities = collect($hotel->amenities ?? [])->filter()->implode(', ');
+
+        return "Hotel profile:\n"
+            ."- Name: {$hotel->name}\n"
+            ."- Location: {$hotel->city}, {$hotel->country}\n"
+            ."- Destination: ".optional($hotel->destination)->name."\n"
+            ."- Stars: ".($hotel->stars ?? 'N/A')."\n"
+            ."- Price per night: ".($hotel->price_per_night ?? 'N/A')."\n"
+            ."- Description: ".($hotel->description ?? 'N/A')."\n"
+            ."- Amenities: ".($amenities ?: 'N/A')."\n"
+            ."- Nearby landmarks: ".($hotel->nearby_landmarks ?? 'N/A')."\n"
+            ."- Check-in/out: ".($hotel->check_in_time?->format('H:i') ?? 'N/A')." / ".($hotel->check_out_time?->format('H:i') ?? 'N/A')."\n"
+            ."- Pets allowed: ".($hotel->pets_allowed ? 'Yes' : 'No')."\n"
+            ."- Policies: ".($hotel->policies ?? 'N/A')."\n\n"
+            ."User question: {$question}\n\n"
+            .'Respond as a professional advisor in concise natural language with clear reasoning, pros/cons when relevant, and actionable tips.';
+    }
+}

--- a/app/Services/AiAssistant/Prompts/TripPromptService.php
+++ b/app/Services/AiAssistant/Prompts/TripPromptService.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Services\AiAssistant\Prompts;
+
+use App\Models\Trip;
+
+class TripPromptService
+{
+    public function systemMessage(): string
+    {
+        return 'You are a trip decision assistant. Help travelers understand whether this trip fits their goals, budget style, and constraints. Provide analytical and personalized recommendations in natural language only.';
+    }
+
+    public function userMessage(Trip $trip, string $question): string
+    {
+        $destinations = $trip->itineraryDestinations->pluck('name')->filter()->implode(', ');
+        $packageSummaries = $trip->packages
+            ->take(5)
+            ->map(fn ($package) => $package->name.' ($'.number_format((float) $package->price, 2).' per person)')
+            ->implode('; ');
+
+        return "Trip profile:\n"
+            ."- Name: {$trip->name}\n"
+            ."- Category: ".($trip->category ?? 'N/A')."\n"
+            ."- Duration days: ".($trip->duration_days ?? 'N/A')."\n"
+            ."- Description: ".($trip->description ?? 'N/A')."\n"
+            ."- Max participants: ".($trip->max_participants ?? 'N/A')."\n"
+            ."- Destinations in itinerary: ".($destinations ?: 'N/A')."\n"
+            ."- Meeting point: ".($trip->meeting_point_description ?? 'N/A')."\n"
+            ."- Meeting address: ".($trip->meeting_point_address ?? 'N/A')."\n"
+            ."- Packages: ".($packageSummaries ?: 'N/A')."\n\n"
+            ."User question: {$question}\n\n"
+            .'Give helpful guidance with clear trade-offs and practical next steps.';
+    }
+}

--- a/resources/views/Destinations/show.blade.php
+++ b/resources/views/Destinations/show.blade.php
@@ -349,25 +349,30 @@ function sendAI() {
     aiResponse.style.display = "block";
     aiResponse.innerHTML = "Thinking... 🤖";
 
-    setTimeout(() => {
-        aiResponse.innerHTML = generateResponse(question);
-    }, 800);
-}
-
-// fake AI brain (مؤقت)
-function generateResponse(q) {
-    q = q.toLowerCase();
-
-    if (q.includes("top")) return "Top attractions include landmarks, viewpoints, and cultural spots worth visiting.";
-    if (q.includes("best time")) return "Best time is usually spring or autumn depending on weather conditions.";
-    if (q.includes("tips")) return "Always plan ahead, avoid peak hours, and keep local currency.";
-    if (q.includes("laws")) return "Laws depends on lifestyle, but mid-range travel is usually safe.";
-    if (q.includes("hidden")) return "Hidden gems are local streets, small cafes, and non-touristic spots.";
-    if (q.includes("food")) return "Try local cuisine, street food, and traditional restaurants.";
-    if (q.includes("safety")) return "Generally safe, just stay aware of surroundings.";
-    if (q.includes("days")) return "Usually 2–5 days are enough depending on itinerary depth.";
-
-    return "Ask me about attractions, food, transport, budget, or travel tips.";
+    fetch("{{ route('ai.destination.ask') }}", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "X-CSRF-TOKEN": "{{ csrf_token() }}"
+        },
+        body: JSON.stringify({
+            entity_id: {{ $destination->id }},
+            question
+        })
+    })
+    .then(async (res) => {
+        const data = await res.json();
+        if (!res.ok) {
+            throw new Error(data.answer || "Could not get AI response.");
+        }
+        return data;
+    })
+    .then((data) => {
+        aiResponse.innerHTML = data.answer;
+    })
+    .catch((error) => {
+        aiResponse.innerHTML = error.message || "Something went wrong. Please try again.";
+    });
 }
         </script>
 
@@ -499,5 +504,4 @@ function generateResponse(q) {
 
 
 </x-app-layout>
-
 

--- a/resources/views/Hotel/show.blade.php
+++ b/resources/views/Hotel/show.blade.php
@@ -368,66 +368,31 @@ document.addEventListener("DOMContentLoaded", function () {
 
         hotelResponse.style.display = "block";
         hotelResponse.innerHTML = "Thinking... 🤖";
-
-        setTimeout(() => {
-            hotelResponse.innerHTML = generateHotelResponse(question);
-        }, 700);
+        fetch("{{ route('ai.hotel.ask') }}", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "X-CSRF-TOKEN": "{{ csrf_token() }}"
+            },
+            body: JSON.stringify({
+                entity_id: {{ $hotel->id }},
+                question
+            })
+        })
+        .then(async (res) => {
+            const data = await res.json();
+            if (!res.ok) {
+                throw new Error(data.answer || "Could not get AI response.");
+            }
+            return data;
+        })
+        .then((data) => {
+            hotelResponse.innerHTML = data.answer;
+        })
+        .catch((error) => {
+            hotelResponse.innerHTML = error.message || "Something went wrong. Please try again.";
+        });
     }
-
-    // fake brain
-    function generateHotelResponse(q) {
-    q = q.toLowerCase();
-
-    const price = {{ $hotel->price_per_night }};
-    const city = "{{ $hotel->destination->city }}";
-    const country = "{{ $hotel->destination->country }}";
-    const amenities = @json($hotel->amenities ?? []);
-    const nearby = "{{ $hotel->nearby_landmarks }}";
-    const pets = "{{ $hotel->pets_allowed }}";
-
-    // 💰 value / worth
-    if (q.includes("worth") || q.includes("price")) {
-        return `At $${price} per night in ${city}, this hotel is ${price > 150 ? "mid-to-high range" : "budget-friendly"}. It offers decent value depending on season and demand.`;
-    }
-
-    // 💑 couples / honeymoon
-    if (q.includes("couple") || q.includes("honeymoon")) {
-        return "This hotel is suitable for couples looking for comfort and convenience. If you want privacy and quiet stay, higher floors are recommended.";
-    }
-
-    // ⚖️ pros & cons
-    if (q.includes("pros") || q.includes("cons")) {
-        return `Pros: good location in ${city}, ${amenities.slice(0,2).join(", ")}. Cons: depends on availability and seasonal pricing.`;
-    }
-
-    // 🛏️ rooms
-    if (q.includes("room")) {
-        return "Higher floors usually offer better views and less noise. Rooms facing city side are more recommended.";
-    }
-
-    // 💸 saving money
-    if (q.includes("save") || q.includes("best price")) {
-        return "Book early or during off-season. Weekdays are usually cheaper than weekends.";
-    }
-
-    // 📍 nearby
-    if (q.includes("nearby")) {
-        return `Around the hotel you can find: ${nearby}. Some hidden local spots are usually within walking distance.`;
-    }
-
-    // 💼 business
-    if (q.includes("business")) {
-        return "Good for business travel due to location and accessibility, but check Wi-Fi speed and workspace availability.";
-    }
-
-    // 🐾 pets
-    if (q.includes("pets")) {
-        return `Pets allowed: ${pets}. Always confirm restrictions for size or breed.`;
-    }
-
-    // default
-    return "I can help you decide if this hotel is worth it, good for couples, business travel, or how to get the best deal.";
-}
     </script>
 
 {{--animation--}}

--- a/resources/views/activities/show.blade.php
+++ b/resources/views/activities/show.blade.php
@@ -517,14 +517,40 @@
 
 <script>
     function askActivityAI(type) {
+        const presetQuestions = {
+            tips: "Give me practical tips to enjoy this activity.",
+            safety: "What safety advice should I follow for this activity?",
+            what_to_bring: "What should I bring for this activity?",
+            best_time: "What is the best time to do this activity?"
+        };
+        const question = presetQuestions[type] ?? "Give me useful planning advice for this activity.";
         const box = document.getElementById('activity-ai-response');
         box.style.display = 'block';
-        box.innerHTML = "Loading...";
+        box.innerHTML = "Thinking...";
 
-        fetch(`/ai/activity/{{ $activity->id }}?type=` + type)
-            .then(res => res.json())
+        fetch("{{ route('ai.activity.ask') }}", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "X-CSRF-TOKEN": "{{ csrf_token() }}"
+            },
+            body: JSON.stringify({
+                entity_id: {{ $activity->id }},
+                question
+            })
+        })
+            .then(async (res) => {
+                const data = await res.json();
+                if (!res.ok) {
+                    throw new Error(data.answer || "Could not get AI response.");
+                }
+                return data;
+            })
             .then(data => {
                 box.innerHTML = data.answer;
+            })
+            .catch((error) => {
+                box.innerHTML = error.message || "Something went wrong. Please try again.";
             });
     }
 
@@ -537,17 +563,29 @@
         box.style.display = 'block';
         box.innerHTML = "Thinking...";
 
-        fetch(`/ai/activity/{{ $activity->id }}`, {
+        fetch("{{ route('ai.activity.ask') }}", {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
                 "X-CSRF-TOKEN": "{{ csrf_token() }}"
             },
-            body: JSON.stringify({ question: input })
+            body: JSON.stringify({
+                entity_id: {{ $activity->id }},
+                question: input
+            })
         })
-        .then(res => res.json())
+        .then(async (res) => {
+            const data = await res.json();
+            if (!res.ok) {
+                throw new Error(data.answer || "Could not get AI response.");
+            }
+            return data;
+        })
         .then(data => {
             box.innerHTML = data.answer;
+        })
+        .catch((error) => {
+            box.innerHTML = error.message || "Something went wrong. Please try again.";
         });
     }
     </script>

--- a/resources/views/trips/user/show.blade.php
+++ b/resources/views/trips/user/show.blade.php
@@ -719,14 +719,40 @@ document.addEventListener('DOMContentLoaded', function () {
 
 <script>
     function askAI(type) {
+        const presetQuestions = {
+            laws: "What important local laws or rules should I know for this trip?",
+            tips: "Give me practical tips to enjoy this trip smoothly.",
+            warnings: "What are the main cautions or common mistakes to avoid on this trip?",
+            costs: "How should I think about budgeting and extra costs for this trip?"
+        };
+        const question = presetQuestions[type] ?? "Give me helpful advice about this trip.";
         const responseBox = document.getElementById('ai-response');
         responseBox.style.display = 'block';
-        responseBox.innerHTML = "Loading...";
+        responseBox.innerHTML = "Thinking...";
 
-        fetch(`/ai/trip/{{ $trip->id }}?type=` + type)
-            .then(res => res.json())
+        fetch("{{ route('ai.trip.ask') }}", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "X-CSRF-TOKEN": "{{ csrf_token() }}"
+            },
+            body: JSON.stringify({
+                entity_id: {{ $trip->id }},
+                question
+            })
+        })
+            .then(async (res) => {
+                const data = await res.json();
+                if (!res.ok) {
+                    throw new Error(data.answer || "Could not get AI response.");
+                }
+                return data;
+            })
             .then(data => {
                 responseBox.innerHTML = data.answer;
+            })
+            .catch((error) => {
+                responseBox.innerHTML = error.message || "Something went wrong. Please try again.";
             });
     }
 
@@ -739,17 +765,29 @@ document.addEventListener('DOMContentLoaded', function () {
         responseBox.style.display = 'block';
         responseBox.innerHTML = "Thinking...";
 
-        fetch(`/ai/trip/{{ $trip->id }}`, {
+        fetch("{{ route('ai.trip.ask') }}", {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
                 "X-CSRF-TOKEN": "{{ csrf_token() }}"
             },
-            body: JSON.stringify({ question: input })
+            body: JSON.stringify({
+                entity_id: {{ $trip->id }},
+                question: input
+            })
         })
-        .then(res => res.json())
+        .then(async (res) => {
+            const data = await res.json();
+            if (!res.ok) {
+                throw new Error(data.answer || "Could not get AI response.");
+            }
+            return data;
+        })
         .then(data => {
             responseBox.innerHTML = data.answer;
+        })
+        .catch((error) => {
+            responseBox.innerHTML = error.message || "Something went wrong. Please try again.";
         });
     }
     </script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,7 @@ use App\Http\Controllers\UserTripController;
 use App\Http\Controllers\TripBookingController;
 use App\Http\Controllers\ReviewController;
 use App\Http\Controllers\ActivityReservationController;
+use App\Http\Controllers\AiAssistantController;
 
 
 
@@ -290,6 +291,12 @@ Route::get('/trip/payment/paypal/callback',
 
 Route::get('/trip-reservations', [TripBookingController::class, 'index'])
 ->name('trip.reservations.index');
+
+// Entity AI assistants
+Route::post('/ai/hotel/ask', [AiAssistantController::class, 'askHotel'])->name('ai.hotel.ask');
+Route::post('/ai/destination/ask', [AiAssistantController::class, 'askDestination'])->name('ai.destination.ask');
+Route::post('/ai/activity/ask', [AiAssistantController::class, 'askActivity'])->name('ai.activity.ask');
+Route::post('/ai/trip/ask', [AiAssistantController::class, 'askTrip'])->name('ai.trip.ask');
 //transport reservations
 Route::get('/vehicle-reservations',  [TransportReservationController::class, 'index'])->name('vehicle.reservations.index');
 //hotel reservations


### PR DESCRIPTION
### Motivation
- Provide real Groq-powered natural-language AI assistants for Hotel, Destination, Activity and Trip pages to replace the existing mock/frontend-only responses. 
- Keep the existing Groq trip-generation pipeline, prompt strategies, catalog, and sanitizers untouched while adding lightweight per-entity prompt builders and an isolated Groq client for conversational answers.

### Description
- Added `AiAssistantController` with four endpoints: `POST /ai/hotel/ask`, `POST /ai/destination/ask`, `POST /ai/activity/ask`, and `POST /ai/trip/ask` that validate input, load entity data, build prompts, call the Groq assistant, and return natural-language answers. 
- Implemented `GroqEntityAssistantService` as a dedicated Groq client (uses `llama-3.3-70b-versatile`) for assistant-style responses separate from the trip planner. 
- Created per-entity prompt builders: `HotelPromptService`, `DestinationPromptService`, `ActivityPromptService`, and `TripPromptService` to assemble system + user messaging without reusing `TripPromptStrategy`. 
- Rewired Blade frontend scripts (hotel, destination, activity, trip views) to call the new API endpoints with `entity_id` + `question` and display natural-language answers, preserving existing UI, presets, and layout.

### Testing
- `php -l` (PHP lint) was executed against all new and modified PHP files and returned no syntax errors. 
- Attempted to run `php artisan route:list` but it failed in this environment due to missing Composer dependencies (`vendor/autoload.php`), so route registration was verified by file diffs instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e515af88b0832fa87e6ad1d8ed3659)