### PR TITLE
Align hotel room images UX and room-type reservation flow

### DIFF
--- a/app/Http/Controllers/HotelController.php
+++ b/app/Http/Controllers/HotelController.php
@@ -281,6 +281,9 @@ private function syncRoomTypes(Hotel $hotel, Request $request, bool $isUpdate): 
         }
 
         $primaryChoice = $roomData['primary_image_choice'] ?? $roomData['primary_new_image_choice'] ?? null;
+        if (!$primaryChoice && array_key_exists('primary_image_index', $roomData) && $roomData['primary_image_index'] !== '') {
+            $primaryChoice = 'new:' . (int) $roomData['primary_image_index'];
+        }
         $roomType->images()->update(['is_primary' => false]);
 
         if (is_string($primaryChoice) && str_starts_with($primaryChoice, 'existing:')) {

--- a/app/Http/Controllers/ReservationController.php
+++ b/app/Http/Controllers/ReservationController.php
@@ -14,10 +14,24 @@ use Illuminate\Support\Facades\DB;
 
 class ReservationController extends Controller
 {
-   public function showReservationForm($id)
+   public function showReservationForm(Request $request, $id)
 {
-    $hotel = Hotel::findOrFail($id);
-    return view('reservation.create', compact('hotel'));
+    $hotel = Hotel::with('roomTypes')->findOrFail($id);
+
+    $selectedRoomType = null;
+    $roomTypeId = $request->integer('room_type_id');
+
+    if ($roomTypeId) {
+        $selectedRoomType = $hotel->roomTypes->firstWhere('id', $roomTypeId);
+    }
+
+    $prefill = [
+        'check_in_date' => $request->input('check_in_date', $request->input('check_in')),
+        'check_out_date' => $request->input('check_out_date', $request->input('check_out')),
+        'guest_count' => $request->input('guest_count', $request->input('guests')),
+    ];
+
+    return view('reservation.create', compact('hotel', 'selectedRoomType', 'prefill'));
 }
 public function store(ReservationRequest $request)
 {

--- a/resources/views/Hotel/edit.blade.php
+++ b/resources/views/Hotel/edit.blade.php
@@ -233,6 +233,7 @@
 
 <script>
 let allFiles = [];
+let roomFilesMap = {};
 
 function addFilesToInput(input) {
     const newFiles = Array.from(input.files);
@@ -243,6 +244,39 @@ function addFilesToInput(input) {
     allFiles.forEach(file => dataTransfer.items.add(file));
 
     input.files = dataTransfer.files;
+}
+
+function handleRoomImages(input, index) {
+    const newFiles = Array.from(input.files);
+
+    if (!roomFilesMap[index]) {
+        roomFilesMap[index] = [];
+    }
+
+    roomFilesMap[index] = roomFilesMap[index].concat(newFiles);
+
+    const select = document.getElementById(`room-primary-select-${index}`);
+    const wrapper = document.getElementById(`room-primary-wrapper-${index}`);
+
+    if (select && wrapper) {
+        if (roomFilesMap[index].length > 0) {
+            select.innerHTML = '';
+            wrapper.classList.remove('hidden');
+
+            roomFilesMap[index].forEach((file, i) => {
+                const option = document.createElement('option');
+                option.value = i;
+                option.textContent = file.name;
+                select.appendChild(option);
+            });
+        } else {
+            wrapper.classList.add('hidden');
+        }
+    }
+
+    const dt = new DataTransfer();
+    roomFilesMap[index].forEach(f => dt.items.add(f));
+    input.files = dt.files;
 }
 </script>
 
@@ -342,14 +376,17 @@ document.addEventListener('DOMContentLoaded', function () {
                 ${existingImagesHtml}
                 <div class="mt-4">
                     <label class="text-sm text-gray-700">Add New Room Images</label>
-                    <input type="file" name="room_types[${index}][images][]" class="mt-1 block w-full" multiple>
-                    <p class="text-xs text-gray-500 mt-1">To set a newly uploaded image as primary, select an option below.</p>
-                    <select name="room_types[${index}][primary_new_image_choice]" class="mt-1 block w-full border-gray-300 rounded-md">
-                        <option value="">Keep current primary</option>
-                        <option value="new:0">First new uploaded image</option>
-                        <option value="new:1">Second new uploaded image</option>
-                        <option value="new:2">Third new uploaded image</option>
-                        <option value="new:3">Fourth new uploaded image</option>
+                    <input type="file"
+                        name="room_types[${index}][images][]"
+                        class="mt-1 block w-full"
+                        multiple
+                        onchange="handleRoomImages(this, ${index})">
+                </div>
+                <div id="room-primary-wrapper-${index}" class="mt-4 hidden">
+                    <label class="text-sm text-gray-700">Primary Image</label>
+                    <select name="room_types[${index}][primary_image_index]"
+                            id="room-primary-select-${index}"
+                            class="mt-1 block w-full border-gray-300 rounded-md">
                     </select>
                 </div>
             </div>

--- a/resources/views/Hotel/show.blade.php
+++ b/resources/views/Hotel/show.blade.php
@@ -325,26 +325,24 @@ document.addEventListener("DOMContentLoaded", function () {
                         <details class="mt-4">
                             <summary class="cursor-pointer inline-flex items-center px-3 py-2 rounded-lg bg-blue-600 text-white text-sm hover:bg-blue-700">Select Room</summary>
                             <div class="mt-4 border border-gray-100 rounded-xl p-4">
-                                <form method="POST" action="{{ route('reservations.store') }}" class="space-y-3">
-                                    @csrf
-                                    <input type="hidden" name="hotel_id" value="{{ $hotel->id }}">
+                                <form method="GET" action="{{ route('reservations.form', $hotel->id) }}" class="space-y-3">
                                     <input type="hidden" name="room_type_id" value="{{ $roomType->id }}">
 
                                     <div>
                                         <label class="block text-xs text-gray-600 mb-1">Check In</label>
-                                        <input type="date" name="check_in" class="w-full border-gray-300 rounded-lg text-sm" required>
+                                        <input type="date" name="check_in_date" class="w-full border-gray-300 rounded-lg text-sm" required>
                                     </div>
                                     <div>
                                         <label class="block text-xs text-gray-600 mb-1">Check Out</label>
-                                        <input type="date" name="check_out" class="w-full border-gray-300 rounded-lg text-sm" required>
+                                        <input type="date" name="check_out_date" class="w-full border-gray-300 rounded-lg text-sm" required>
                                     </div>
                                     <div>
                                         <label class="block text-xs text-gray-600 mb-1">Guests</label>
-                                        <input type="number" min="1" name="guests" class="w-full border-gray-300 rounded-lg text-sm" required>
+                                        <input type="number" min="1" name="guest_count" class="w-full border-gray-300 rounded-lg text-sm" required>
                                     </div>
 
                                     <button type="submit" class="w-full bg-green-600 text-white py-2 rounded-lg text-sm hover:bg-green-700">
-                                        Confirm & Continue
+                                        Continue
                                     </button>
                                 </form>
                             </div>

--- a/resources/views/reservation/create.blade.php
+++ b/resources/views/reservation/create.blade.php
@@ -31,34 +31,46 @@
                 <form action="{{ route('reservations.store') }}" method="POST">
                     @csrf
                     <input type="hidden" name="hotel_id" value="{{ $hotel->id }}">
+                    @if(!empty($selectedRoomType))
+                        <input type="hidden" name="room_type_id" value="{{ $selectedRoomType->id }}">
+                    @endif
                     <div class="mb-6">
                         <p class="font-semibold text-xl text-indigo-900 leading-tight">
-                            Room price per night in this hotel is {{$hotel->price_per_night}}</p>
+                            @if(!empty($selectedRoomType))
+                                Selected room type: {{ $selectedRoomType->name }} ({{ number_format($selectedRoomType->price_per_night, 2) }} / night)
+                            @else
+                                Room price per night in this hotel is {{ $hotel->price_per_night }}
+                            @endif
+                        </p>
                     </div>
 
 
                     <!-- Guest Count -->
                     <div class="mb-4">
                         <label class="block text-gray-700">Number of Guests</label>
-                        <input type="number" name="guest_count" class="form-input w-full" required>
+                        <input type="number" name="guest_count" class="form-input w-full" value="{{ old('guest_count', $prefill['guest_count'] ?? '') }}" required>
                     </div>
 
                     <!-- Rooms Count -->
-                    <div class="mb-4">
-                        <label class="block text-gray-700">Number of Rooms</label>
-                        <input type="number" name="rooms_count" class="form-input w-full" required>
-                    </div>
+                    @if(empty($selectedRoomType))
+                        <div class="mb-4">
+                            <label class="block text-gray-700">Number of Rooms</label>
+                            <input type="number" name="rooms_count" class="form-input w-full" value="{{ old('rooms_count', 1) }}" required>
+                        </div>
+                    @else
+                        <input type="hidden" name="rooms_count" value="1">
+                    @endif
 
                     <!-- Check-in Date -->
                     <div class="mb-4">
                         <label class="block text-gray-700">Check-In Date</label>
-                        <input type="date" name="check_in_date" class="form-input w-full" required>
+                        <input type="date" name="check_in_date" class="form-input w-full" value="{{ old('check_in_date', $prefill['check_in_date'] ?? '') }}" required>
                     </div>
 
                     <!-- Check-out Date -->
                     <div class="mb-4">
                         <label class="block text-gray-700">Check-Out Date</label>
-                        <input type="date" name="check_out_date" class="form-input w-full" required>
+                        <input type="date" name="check_out_date" class="form-input w-full" value="{{ old('check_out_date', $prefill['check_out_date'] ?? '') }}" required>
                     </div>
 
                     <!-- Name -->


### PR DESCRIPTION
### Motivation
- Unify the room-type images UX so the `Edit Hotel` form behaves the same as `Create Hotel` (incremental multi-file uploads + dynamic primary-image selector). 
- Make the room booking flow consistent: when a user selects a room on the hotel `show` page they should be taken to the reservation form (pre-filled) and then continue to payment, with total price derived from the selected room type.

### Description
- Updated `resources/views/Hotel/edit.blade.php` to implement the same multi-file accumulation and dynamic per-room-type primary-image dropdown used on create, and added client-side `handleRoomImages` logic to populate the selector. 
- Enhanced `app/Http/Controllers/HotelController.php::syncRoomTypes` to accept `primary_image_index` (the create/edit dropdown style) and map it to the existing primary-image selection flow. 
- Changed the hotel listing on `resources/views/Hotel/show.blade.php` so the `Select Room` form submits a `GET` to the reservation form (`reservations.form`) with `room_type_id`, `check_in_date`, `check_out_date`, and `guest_count` instead of posting a reservation directly. 
- Modified `app/Http/Controllers/ReservationController.php::showReservationForm` to accept `Request`, load `roomTypes`, resolve a `selectedRoomType`, and build a `prefill` payload for dates/guests so the reservation form can be pre-populated. 
- Updated `resources/views/reservation/create.blade.php` to show the selected room type and price, include a hidden `room_type_id` when present, prefill `check_in_date`/`check_out_date`/`guest_count`, and fix `rooms_count=1` for room-type bookings (ensures final price calculation uses the chosen room type price). 
- Files changed: `app/Http/Controllers/HotelController.php`, `app/Http/Controllers/ReservationController.php`, `resources/views/Hotel/edit.blade.php`, `resources/views/Hotel/show.blade.php`, and `resources/views/reservation/create.blade.php`.

### Testing
- Ran `php -l` syntax checks for `app/Http/Controllers/ReservationController.php`, `app/Http/Controllers/HotelController.php`, `resources/views/reservation/create.blade.php`, `resources/views/Hotel/show.blade.php`, and `resources/views/Hotel/edit.blade.php` which reported no syntax errors. 
- Attempted to run the test suite with `php artisan test --filter=Reservation --stop-on-failure`, but it could not run in this environment because `vendor/autoload.php` is missing (dependencies are not installed), so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e53fa5607c832f86b6be228449845f)