### PR TITLE
Show room type details and gallery in hotel edit form

### DIFF
--- a/resources/views/Hotel/edit.blade.php
+++ b/resources/views/Hotel/edit.blade.php
@@ -222,6 +222,50 @@
     </div>
 </div>
         @endif
+
+@if($hotel->roomTypes->count())
+<div class="mt-10">
+    <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-4">Room Types & Images</h3>
+
+    <div class="space-y-8">
+        @foreach($hotel->roomTypes as $roomType)
+            <div class="border rounded-xl p-4 bg-white dark:bg-gray-900">
+                <div class="mb-4">
+                    <h4 class="text-md font-semibold text-gray-800 dark:text-gray-100">{{ $roomType->name }}</h4>
+                    <p class="text-sm text-gray-600 dark:text-gray-300">
+                        Price: ${{ number_format($roomType->price_per_night, 2) }} |
+                        Capacity: {{ $roomType->capacity }} |
+                        Quantity: {{ $roomType->quantity }}
+                    </p>
+                    @if($roomType->description)
+                        <p class="text-sm text-gray-500 mt-1">{{ $roomType->description }}</p>
+                    @endif
+                </div>
+
+                @if($roomType->images->count())
+                    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+                        @foreach($roomType->images as $image)
+                            <div class="relative group border rounded shadow overflow-hidden h-48 bg-white dark:bg-gray-900">
+                                <img src="{{ asset('storage/' . $image->image_url) }}"
+                                    class="w-full h-full object-cover"
+                                    alt="{{ $roomType->name }} image">
+
+                                @if ($image->is_primary)
+                                    <span class="absolute bottom-2 left-2 bg-green-600 text-white text-xs px-3 py-1 rounded shadow">
+                                        Primary
+                                    </span>
+                                @endif
+                            </div>
+                        @endforeach
+                    </div>
+                @else
+                    <p class="text-sm text-gray-500">No images uploaded for this room type.</p>
+                @endif
+            </div>
+        @endforeach
+    </div>
+</div>
+@endif
             </div>
         </div>
     </div>


### PR DESCRIPTION
### Motivation
- Allow administrators to see each room type's core details and gallery while editing a hotel so room-type data is more discoverable and manageable in the edit flow.
- Reuse the existing visual style for hotel images so the room type galleries match the hotel's primary images presentation.

### Description
- Added a new `Room Types & Images` section to the hotel edit view at `resources/views/Hotel/edit.blade.php` that lists each room type's name, price, capacity, quantity, and description.
- Rendered each room type's images in a card grid matching the hotel images grid and added a `Primary` badge for primary room-type images.
- Provided a fallback message when a room type has no images.
- This is a view-only change and no controller or model updates were required because room types and images are already eager-loaded in the edit action.

### Testing
- Ran a PHP lint check with `php -l resources/views/Hotel/edit.blade.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e546a480d8832faaaa91c0b6605cdc)