### PR TITLE
Add dedicated room types editor linked from hotel edit page

### DIFF
--- a/app/Http/Controllers/HotelController.php
+++ b/app/Http/Controllers/HotelController.php
@@ -9,6 +9,7 @@ use App\Models\HotelImage;
 use App\Models\RoomType;
 use App\Models\Reservation;
 use App\Http\Requests\HotelRequest;
+use App\Http\Requests\HotelRoomTypesRequest;
 use App\Services\MediaServices;
 use Illuminate\Support\Facades\Storage;
 use App\Services\GeocodingService;
@@ -178,6 +179,25 @@ public function edit($id)
     $hotel = Hotel::with(['images', 'roomTypes.images'])->findOrFail($id);
     $destinations = Destination::all();
     return view('hotel.edit', compact('hotel', 'destinations'));
+}
+
+public function editRoomTypes($id)
+{
+    $hotel = Hotel::with(['roomTypes.images'])->findOrFail($id);
+
+    return view('Hotel.room-types-edit', compact('hotel'));
+}
+
+public function updateRoomTypes(HotelRoomTypesRequest $request, $id)
+{
+    $hotel = Hotel::with('roomTypes.images')->findOrFail($id);
+
+    DB::transaction(function () use ($request, $hotel) {
+        $this->syncRoomTypes($hotel, $request, true);
+    });
+
+    return redirect()->route('hotels.edit', $hotel->id)
+        ->with('success', 'Room types updated successfully.');
 }
 
 ///update

--- a/app/Http/Requests/HotelRoomTypesRequest.php
+++ b/app/Http/Requests/HotelRoomTypesRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class HotelRoomTypesRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'room_types' => 'nullable|array',
+            'room_types.*.id' => 'nullable|integer|exists:room_types,id',
+            'room_types.*.name' => 'required_with:room_types|string|max:255',
+            'room_types.*.price_per_night' => 'required_with:room_types|numeric|gt:0',
+            'room_types.*.capacity' => 'required_with:room_types|integer|gt:0',
+            'room_types.*.quantity' => 'required_with:room_types|integer|min:0',
+            'room_types.*.description' => 'nullable|string',
+            'room_types.*.amenities' => 'nullable|string',
+            'room_types.*.is_refundable' => 'nullable|boolean',
+            'room_types.*.images' => 'nullable|array',
+            'room_types.*.images.*' => 'image|mimes:jpeg,png,jpg,gif',
+            'room_types.*.primary_image_choice' => 'nullable|string',
+            'room_types.*.primary_new_image_choice' => 'nullable|string',
+            'room_types.*.remove_existing_image_ids' => 'nullable|array',
+            'room_types.*.remove_existing_image_ids.*' => 'integer|exists:room_type_images,id',
+        ];
+    }
+}

--- a/resources/views/Hotel/edit.blade.php
+++ b/resources/views/Hotel/edit.blade.php
@@ -6,7 +6,12 @@
 
 
     <div class="vehicle-form-container"> 
-        <h2 class="text-2xl font-bold text-gray-800 mb-6">Edit Hotel</h2>
+        <div class="flex items-center justify-between mb-6">
+        <h2 class="text-2xl font-bold text-gray-800">Edit Hotel</h2>
+        <a href="{{ route('hotels.room-types.edit', $hotel->id) }}" class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700">
+            Edit Room Types
+        </a>
+        </div>
 
         <form action="{{ route('hotels.update', $hotel) }}" method="post" enctype="multipart/form-data">
             @csrf

--- a/resources/views/Hotel/room-types-edit.blade.php
+++ b/resources/views/Hotel/room-types-edit.blade.php
@@ -1,0 +1,182 @@
+<x-app-layout>
+    @push('styles')
+        <link rel="stylesheet" href="{{ asset('css/transport.css') }}">
+        <link rel="stylesheet" href="{{ asset('css/vehicles.css') }}">
+    @endpush
+
+    <div class="vehicle-form-container">
+        <div class="flex items-center justify-between mb-6">
+            <h2 class="text-2xl font-bold text-gray-800">Edit Room Types — {{ $hotel->name }}</h2>
+            <a href="{{ route('hotels.edit', $hotel->id) }}" class="px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300">
+                ← Back to Edit Hotel
+            </a>
+        </div>
+
+        <form action="{{ route('hotels.room-types.update', $hotel->id) }}" method="post" enctype="multipart/form-data">
+            @csrf
+            @method('PUT')
+
+            @if ($errors->any())
+                <div class="mb-4 px-4 py-3 bg-red-100 text-red-800 rounded">
+                    <ul class="list-disc list-inside">
+                        @foreach ($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+
+            <div class="mt-2">
+                <h3 class="text-xl font-semibold text-gray-800 mb-2">🏨 Room Types</h3>
+                <p class="text-sm text-gray-500 mb-4">Manage existing room types, images, and add new ones.</p>
+                <div id="room-types-container" class="space-y-6"></div>
+                <button type="button" id="add-room-type-btn" class="mt-4 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700">
+                    + Add Room Type
+                </button>
+            </div>
+
+            <div class="popup-buttons mt-8">
+                <button type="submit" class="btn btn-primary">Update Room Types</button>
+                <a href="{{ route('hotels.edit', $hotel->id) }}" class="cancel-btn">Cancel</a>
+            </div>
+        </form>
+    </div>
+
+    @php
+    $existingRoomTypes = old('room_types',
+        $hotel->roomTypes->map(function ($roomType) {
+            return [
+                'id' => $roomType->id,
+                'name' => $roomType->name,
+                'price_per_night' => $roomType->price_per_night,
+                'capacity' => $roomType->capacity,
+                'quantity' => $roomType->quantity,
+                'description' => $roomType->description,
+                'amenities' => is_array($roomType->amenities)
+                    ? implode(', ', $roomType->amenities)
+                    : '',
+                'is_refundable' => $roomType->is_refundable,
+                'images' => $roomType->images->map(function ($image) {
+                    return [
+                        'id' => $image->id,
+                        'image_url' => $image->image_url,
+                        'is_primary' => $image->is_primary,
+                    ];
+                })->values()->all(),
+            ];
+        })->values()->all()
+    );
+    @endphp
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const container = document.getElementById('room-types-container');
+            const addBtn = document.getElementById('add-room-type-btn');
+            let roomTypeIndex = 0;
+
+            const existingRoomTypes = @json($existingRoomTypes);
+
+            const roomTypeTemplate = (index, values = {}) => {
+                const existingImages = Array.isArray(values.images) ? values.images : [];
+
+                const existingImagesHtml = existingImages.length
+                    ? `<div class="mt-4">
+                        <p class="text-sm text-gray-700 mb-2">Existing Images</p>
+                        <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+                            ${existingImages.map(image => `
+                                <div class="border rounded-lg p-2">
+                                    <img src="/storage/${image.image_url}" class="w-full h-20 object-cover rounded">
+                                    <div class="mt-2 space-y-2">
+                                        <label class="text-xs block">
+                                            <input type="radio"
+                                                name="room_types[${index}][primary_image_choice]"
+                                                value="existing:${image.id}"
+                                                ${image.is_primary ? 'checked' : ''}>
+                                            Primary
+                                        </label>
+                                        <label class="text-xs block text-red-700">
+                                            <input type="checkbox"
+                                                name="room_types[${index}][remove_existing_image_ids][]"
+                                                value="${image.id}">
+                                            Remove image
+                                        </label>
+                                    </div>
+                                </div>
+                            `).join('')}
+                        </div>
+                    </div>`
+                    : '';
+
+                return `
+                <div class="border rounded-xl p-5 bg-white room-type-card space-y-3">
+                    <input type="hidden" name="room_types[${index}][id]" value="${values.id ?? ''}">
+
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label class="text-sm text-gray-600">Room Type Name</label>
+                            <input type="text" name="room_types[${index}][name]"
+                                value="${values.name ?? ''}" placeholder="Name" class="mt-1 w-full border rounded-md" required>
+                        </div>
+
+                        <div>
+                            <label class="text-sm text-gray-600">Price Per Night</label>
+                            <input type="number" step="0.01" min="0.01" name="room_types[${index}][price_per_night]"
+                                value="${values.price_per_night ?? ''}" placeholder="Price" class="mt-1 w-full border rounded-md" required>
+                        </div>
+
+                        <div>
+                            <label class="text-sm text-gray-600">Capacity</label>
+                            <input type="number" min="1" name="room_types[${index}][capacity]"
+                                value="${values.capacity ?? ''}" placeholder="Capacity" class="mt-1 w-full border rounded-md" required>
+                        </div>
+
+                        <div>
+                            <label class="text-sm text-gray-600">Quantity</label>
+                            <input type="number" min="0" name="room_types[${index}][quantity]"
+                                value="${values.quantity ?? ''}" placeholder="Quantity" class="mt-1 w-full border rounded-md" required>
+                        </div>
+                    </div>
+
+                    <div>
+                        <label class="text-sm text-gray-600">Description</label>
+                        <textarea name="room_types[${index}][description]" class="mt-1 w-full border rounded-md">${values.description ?? ''}</textarea>
+                    </div>
+
+                    <div>
+                        <label class="text-sm text-gray-600">Amenities (comma separated)</label>
+                        <input type="text" name="room_types[${index}][amenities]"
+                            value="${values.amenities ?? ''}" class="mt-1 w-full border rounded-md" placeholder="Wifi, AC, Balcony">
+                    </div>
+
+                    <label class="text-sm text-gray-700 block">
+                        <input type="checkbox" name="room_types[${index}][is_refundable]" value="1" ${values.is_refundable ? 'checked' : ''}>
+                        Refundable
+                    </label>
+
+                    ${existingImagesHtml}
+
+                    <div>
+                        <label class="text-sm text-gray-600">Upload New Images</label>
+                        <input type="file" name="room_types[${index}][images][]" multiple class="mt-1 block w-full text-sm text-gray-500">
+                        <p class="text-xs text-gray-500 mt-1">After upload, choose primary image by selecting one of existing images or by new index in backend default (first image).</p>
+                    </div>
+                </div>`;
+            };
+
+            function addRoomType(values = {}) {
+                const wrapper = document.createElement('div');
+                wrapper.innerHTML = roomTypeTemplate(roomTypeIndex, values);
+                container.appendChild(wrapper.firstElementChild);
+                roomTypeIndex++;
+            }
+
+            if (existingRoomTypes.length) {
+                existingRoomTypes.forEach(rt => addRoomType(rt));
+            } else {
+                addRoomType();
+            }
+
+            addBtn.addEventListener('click', () => addRoomType());
+        });
+    </script>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -82,6 +82,8 @@ Route::delete('/destinations/{id}', [DestinationController::class, 'destroyDesti
 Route::get('/hotels/create',[HotelController::class,'create'])->name('hotels.create');
 Route::post('/hotels',[HotelController::class,'store'])->name('hotels.store');
 Route::get('/hotels/{hotel}/edit', [HotelController::class, 'edit'])->name('hotels.edit');
+Route::get('/hotels/{id}/room-types/edit', [HotelController::class, 'editRoomTypes'])->name('hotels.room-types.edit');
+Route::put('/hotels/{id}/room-types', [HotelController::class, 'updateRoomTypes'])->name('hotels.room-types.update');
 Route::put('hotels/{id}',[HotelController::class,'update'])->name('hotels.update');
 Route::delete('hotels/images/{id}',[HotelController::class,'destroyImage'])->name('hotel-images.destroy');
 Route::post('hotels/images/{id}/set-primary', [HotelController::class, 'setPrimaryImage'])->name('hotel-images.setPrimary');


### PR DESCRIPTION
### Motivation
- Provide a focused form for editing a hotel's room types (fields, images, primary selection, removal, and new uploads) while keeping the main `edit hotel` page unchanged in layout.
- Make room-type-only updates validate and process separately so editors can manage room types without touching the main hotel update payload.

### Description
- Added a new admin route pair: `GET /hotels/{id}/room-types/edit` and `PUT /hotels/{id}/room-types` registered under `hotels.room-types.edit` and `hotels.room-types.update` in `routes/web.php`.
- Introduced `HotelRoomTypesRequest` for validating room-type-only payloads in `app/Http/Requests/HotelRoomTypesRequest.php`.
- Extended `HotelController` with `editRoomTypes` and `updateRoomTypes` methods which reuse the existing `syncRoomTypes` logic to create/update/delete room types and their images (`app/Http/Controllers/HotelController.php`).
- Added an `Edit Room Types` button to the top of the hotel edit page that links to the new form (`resources/views/Hotel/edit.blade.php`).
- Created a new view `resources/views/Hotel/room-types-edit.blade.php` that follows the `edit hotel` design and provides dynamic JS-driven room-type cards supporting existing images, primary selection, removal checkboxes, new uploads, and adding new room types.

### Testing
- `php -l app/Http/Controllers/HotelController.php` reported no syntax errors.
- `php -l app/Http/Requests/HotelRoomTypesRequest.php` reported no syntax errors.
- `php artisan route:list --name=hotels.room-types` could not be run successfully in this environment due to a missing Composer autoload (`vendor/autoload.php`) and therefore route list verification failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e547e8a5c8832fa6af2613cf7de54f)