### PR TITLE
Fix room-types edit image upload and add remove button

### DIFF
--- a/resources/views/Hotel/room-types/edit.blade.php
+++ b/resources/views/Hotel/room-types/edit.blade.php
@@ -64,49 +64,50 @@
     <script>
     const existing = @json($rooms);
     let i = 0;
-    const fileStore = {};
-    
+
+    function removeRoomType(card) {
+        card.remove();
+    }
+
     function handleFiles(input, index) {
-        const newFiles = Array.from(input.files);
-    
-        if (!fileStore[index]) fileStore[index] = [];
-    
-        fileStore[index] = fileStore[index].concat(newFiles);
-    
         const preview = document.getElementById(`preview-${index}`);
         const select = document.getElementById(`primary-${index}`);
-    
+        const files = Array.from(input.files || []);
+
         preview.innerHTML = '';
         select.innerHTML = `<option value="">Select primary image</option>`;
-    
-        fileStore[index].forEach((file, idx) => {
-    
+
+        files.forEach((file, idx) => {
             const reader = new FileReader();
-    
             reader.onload = e => {
                 const img = document.createElement('img');
                 img.src = e.target.result;
                 img.className = "h-20 w-full object-cover rounded mb-1";
                 preview.appendChild(img);
             };
-    
             reader.readAsDataURL(file);
-    
+
             const opt = document.createElement('option');
-            opt.value = `new:${idx}`;
+            opt.value = `${idx}`;
             opt.text = file.name;
             select.appendChild(opt);
         });
-    
-        input.value = '';
     }
     
     function template(i, r = {}) {
     
         return `
-        <div class="border rounded-xl p-5 bg-white mb-6">
-    
+        <div class="border rounded-xl p-5 bg-white mb-6 room-type-card">
+
             <input type="hidden" name="room_types[${i}][id]" value="${r.id ?? ''}">
+
+            <div class="flex justify-end mb-3">
+                <button type="button"
+                        class="px-3 py-1.5 text-sm bg-red-600 text-white rounded-md hover:bg-red-700"
+                        onclick="removeRoomType(this.closest('.room-type-card'))">
+                    Remove
+                </button>
+            </div>
     
             <label class="block font-semibold">Room Name</label>
             <input class="border rounded-md w-full mb-3 p-2"
@@ -178,7 +179,11 @@
         document.getElementById('room-container').appendChild(div.firstElementChild);
     }
     
-    existing.forEach(r => add(r));
+    if (existing.length) {
+        existing.forEach(r => add(r));
+    } else {
+        add();
+    }
     
     document.getElementById('add').onclick = () => add();
     


### PR DESCRIPTION
### Motivation
- The room-type edit form was clearing the file input after selection, causing uploaded images not to be submitted and thus not saved.
- Users need an easy way to remove room types from the edit form immediately (both existing and newly added) before saving.

### Description
- Updated `resources/views/Hotel/room-types/edit.blade.php` to stop clearing the file input and instead read `input.files` for previews so selected files are submitted with the form.  
- Changed the new-primary selection values for uploaded images to numeric indices (`0,1,2...`) to match backend handling.  
- Added a `Remove` button inside each room-type card that removes the card from the DOM immediately when clicked.  
- Ensure the UI initializes with at least one room-type card when there are no existing room types.

### Testing
- Ran `php -l resources/views/Hotel/room-types/edit.blade.php` which returned no syntax errors.  
- Ran `php -l app/Http/Controllers/RoomTypeController.php` which returned no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e68fa3dd408330b44565063834aeb8)