### PR TITLE
Improve room-type image handling, add remove button, and ensure default card rendering

### DIFF
--- a/resources/views/Hotel/room-types/edit.blade.php
+++ b/resources/views/Hotel/room-types/edit.blade.php
@@ -64,49 +64,76 @@
     <script>
     const existing = @json($rooms);
     let i = 0;
-    const fileStore = {};
-    
+    const roomTypeSelectedFiles = {};
+
+    function removeRoomType(card) {
+        const cardIndex = card.dataset.roomTypeIndex;
+        if (cardIndex !== undefined) {
+            delete roomTypeSelectedFiles[cardIndex];
+        }
+        card.remove();
+    }
+
     function handleFiles(input, index) {
-        const newFiles = Array.from(input.files);
-    
-        if (!fileStore[index]) fileStore[index] = [];
-    
-        fileStore[index] = fileStore[index].concat(newFiles);
-    
         const preview = document.getElementById(`preview-${index}`);
         const select = document.getElementById(`primary-${index}`);
-    
+        const incomingFiles = Array.from(input.files || []);
+
+        if (!roomTypeSelectedFiles[index]) {
+            roomTypeSelectedFiles[index] = [];
+        }
+
+        const currentFiles = roomTypeSelectedFiles[index];
+        incomingFiles.forEach(file => {
+            const exists = currentFiles.some(existingFile =>
+                existingFile.name === file.name
+                && existingFile.size === file.size
+                && existingFile.lastModified === file.lastModified
+            );
+
+            if (!exists) {
+                currentFiles.push(file);
+            }
+        });
+
+        const dataTransfer = new DataTransfer();
+        currentFiles.forEach(file => dataTransfer.items.add(file));
+        input.files = dataTransfer.files;
+
         preview.innerHTML = '';
         select.innerHTML = `<option value="">Select primary image</option>`;
-    
-        fileStore[index].forEach((file, idx) => {
-    
+
+        currentFiles.forEach((file, idx) => {
             const reader = new FileReader();
-    
             reader.onload = e => {
                 const img = document.createElement('img');
                 img.src = e.target.result;
                 img.className = "h-20 w-full object-cover rounded mb-1";
                 preview.appendChild(img);
             };
-    
             reader.readAsDataURL(file);
-    
+
             const opt = document.createElement('option');
-            opt.value = `new:${idx}`;
+            opt.value = `${idx}`;
             opt.text = file.name;
             select.appendChild(opt);
         });
-    
-        input.value = '';
     }
     
     function template(i, r = {}) {
     
         return `
-        <div class="border rounded-xl p-5 bg-white mb-6">
-    
+        <div class="border rounded-xl p-5 bg-white mb-6 room-type-card" data-room-type-index="${i}">
+
             <input type="hidden" name="room_types[${i}][id]" value="${r.id ?? ''}">
+
+            <div class="flex justify-end mb-3">
+                <button type="button"
+                        class="px-3 py-1.5 text-sm bg-red-600 text-white rounded-md hover:bg-red-700"
+                        onclick="removeRoomType(this.closest('.room-type-card'))">
+                    Remove
+                </button>
+            </div>
     
             <label class="block font-semibold">Room Name</label>
             <input class="border rounded-md w-full mb-3 p-2"
@@ -178,7 +205,11 @@
         document.getElementById('room-container').appendChild(div.firstElementChild);
     }
     
-    existing.forEach(r => add(r));
+    if (existing.length) {
+        existing.forEach(r => add(r));
+    } else {
+        add();
+    }
     
     document.getElementById('add').onclick = () => add();
     


### PR DESCRIPTION
### Motivation
- Prevent duplicate file entries when selecting images for a room type and persist per-room-type file lists in the UI.
- Allow removing a room-type card and its associated staged files from the client-side form before submission.
- Ensure the form shows at least one room-type card when there are no existing room types for the hotel.

### Description
- Replaced the global `fileStore` with `roomTypeSelectedFiles` and updated `handleFiles` to dedupe incoming files by `name`, `size`, and `lastModified` before storing them.
- Updated `handleFiles` to rebuild `input.files` using `DataTransfer` so the file input reflects the de-duplicated file list, and updated preview and primary-select population accordingly.
- Added `removeRoomType(card)` to remove a room-type card DOM node and clear its entry from `roomTypeSelectedFiles`.
- Modified the room-type template to include a `room-type-card` wrapper with `data-room-type-index`, a `Remove` button that calls `removeRoomType`, and a hidden `id` input for existing records.
- Changed generated option values for newly added images to use the numeric index instead of the `new:` prefix and ensured the form will render at least one empty card when there are no existing room types.

### Testing
- Ran the existing Laravel test suite with `php artisan test` and the suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e68fa3dd408330b44565063834aeb8)