### PR TITLE
Add activity review flow (models, controller, views, routes, notifications, migration)

### DIFF
--- a/app/Console/Commands/CheckReviewableCompletions.php
+++ b/app/Console/Commands/CheckReviewableCompletions.php
@@ -7,6 +7,7 @@ use Illuminate\Console\Command;
 use App\Models\Reservation;
 use App\Models\TripReservation;
 use App\Models\TransportReservation;
+use App\Models\ActivityReservation;
 
 use App\Events\ReviewableItemCompleted;
 
@@ -21,6 +22,7 @@ class CheckReviewableCompletions extends Command
         $this->checkHotels();
         $this->checkTrips();
         $this->checkDrivers();
+        $this->checkActivities();
 
         $this->info('Review completion check done.');
     }
@@ -120,6 +122,30 @@ class CheckReviewableCompletions extends Command
 
             $reservation->update([
                 'driver_review_notification_sent' => true
+            ]);
+        }
+    }
+
+    /**
+     * ACTIVITIES
+     */
+    private function checkActivities()
+    {
+        $reservations = ActivityReservation::where('status', 'confirmed')
+            ->where('activity_date', '<', now())
+            ->where('activity_review_notification_sent', false)
+            ->get();
+
+        foreach ($reservations as $reservation) {
+            event(new ReviewableItemCompleted(
+                type: 'activity',
+                id: $reservation->activity_id,
+                userId: $reservation->user_id,
+                reservationId: $reservation->id
+            ));
+
+            $reservation->update([
+                'activity_review_notification_sent' => true,
             ]);
         }
     }

--- a/app/Http/Controllers/ActivityController.php
+++ b/app/Http/Controllers/ActivityController.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Storage;
 use App\Services\GeocodingService;
 use App\Models\ActivityHighlight;
 use App\Http\Requests\ActivityHighlightRequest;
+use App\Services\Review\ReviewEligibilityService;
 
 class ActivityController extends Controller
 {
@@ -109,9 +110,9 @@ class ActivityController extends Controller
 
 
 
-  public function show($id, GeocodingService $geo)
+  public function show($id, GeocodingService $geo, ReviewEligibilityService $eligibilityService)
 {
-    $activity = Activity::with(['destination','highlights'])->findOrFail($id);
+    $activity = Activity::with(['destination','highlights', 'reviews.user'])->findOrFail($id);
     $hasPaidReservation = $activity->reservations()
         ->where('user_id', auth()->id())
         ->where('status', 'confirmed')
@@ -131,7 +132,22 @@ class ActivityController extends Controller
         $coords = null;
     }
 
-    return view('activities.show', compact('activity', 'hasPaidReservation', 'coords'));
+    $averageRating = $activity->reviews()->avg('rating');
+    $reviewsCount = $activity->reviews()->count();
+    $reviews = $activity->reviews()->latest()->get();
+
+    $reviewReservation = $activity->reservations()
+        ->where('user_id', auth()->id())
+        ->where('status', 'confirmed')
+        ->where('activity_date', '<', now())
+        ->latest('activity_date')
+        ->first();
+
+    $canReview = auth()->check() && $reviewReservation
+        ? $eligibilityService->canReview(auth()->user(), 'activity', (int) $activity->id, (int) $reviewReservation->id)
+        : false;
+
+    return view('activities.show', compact('activity', 'hasPaidReservation', 'coords', 'averageRating', 'reviewsCount', 'reviews', 'canReview', 'reviewReservation'));
 }
 
     /**

--- a/app/Http/Controllers/ReviewController.php
+++ b/app/Http/Controllers/ReviewController.php
@@ -14,6 +14,7 @@ use App\Models\Hotel;
 use App\Models\Trip;
 use App\Models\Driver;
 use App\Models\Guide;
+use App\Models\Activity;
 use App\Models\Review;
 
 class ReviewController extends Controller
@@ -36,6 +37,7 @@ class ReviewController extends Controller
             'hotel' => \App\Models\Hotel::class,
             'trip' => \App\Models\Trip::class,
             'guide' => \App\Models\Guide::class,
+            'activity' => \App\Models\Activity::class,
             'driver' => \App\Models\Driver::class,
         ];
 
@@ -80,6 +82,7 @@ class ReviewController extends Controller
             'trip' => Trip::findOrFail($request->id),
             'driver' => Driver::findOrFail($request->id),
             'guide' => Guide::findOrFail($request->id),
+            'activity' => Activity::findOrFail($request->id),
         };
 
         $reservation = $eligibilityService->resolveOwnedReservation(
@@ -180,6 +183,15 @@ public function guideIndex(string $id)
     $avg = $guide->reviews()->avg('rating');
 
     return view('reviews.guide-index', compact('guide', 'reviews', 'avg'));
+}
+
+public function activityIndex(string $id)
+{
+    $activity = Activity::with('reviews.user')->findOrFail($id);
+
+    $reviews = $activity->reviews()->latest()->get();
+
+    return view('reviews.activity-index', compact('activity', 'reviews'));
 }
 
 }

--- a/app/Http/Requests/StoreReviewRequest.php
+++ b/app/Http/Requests/StoreReviewRequest.php
@@ -14,7 +14,7 @@ class StoreReviewRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'type' => ['required', 'string', Rule::in(['hotel', 'trip', 'guide', 'driver'])],
+            'type' => ['required', 'string', Rule::in(['hotel', 'trip', 'guide', 'driver', 'activity'])],
             'id' => ['required', 'integer', 'min:1'],
             'reservation_id' => ['required', 'integer', 'min:1'],
             'rating' => ['required', 'integer', 'min:1', 'max:5'],

--- a/app/Listeners/SendReviewRequestNotification.php
+++ b/app/Listeners/SendReviewRequestNotification.php
@@ -38,6 +38,8 @@ class SendReviewRequestNotification
 
             'guide' => \App\Models\Guide::find($id)?->name ?? 'Guide',
 
+            'activity' => \App\Models\Activity::find($id)?->name ?? 'Activity',
+
             default => 'Item',
         };
     }

--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Favorite;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use App\Models\Review;
 
 class Activity extends Model
 {
@@ -71,8 +72,18 @@ class Activity extends Model
     return $this->hasMany(ActivityReservation::class);
    }
 
-   public function highlights()
+public function highlights()
 {
     return $this->hasMany(ActivityHighlight::class);
+}
+
+public function reviews(): MorphMany
+{
+    return $this->morphMany(Review::class, 'reviewable');
+}
+
+public function getAverageRatingAttribute()
+{
+    return round($this->reviews()->avg('rating') ?? 0, 1);
 }
 }

--- a/app/Models/ActivityReservation.php
+++ b/app/Models/ActivityReservation.php
@@ -17,6 +17,7 @@ class ActivityReservation extends Model
         'participants_count',
         'total_price',
         'status',
+        'activity_review_notification_sent',
     ];
 
     protected $hidden = [

--- a/app/Services/Review/ReviewEligibilityService.php
+++ b/app/Services/Review/ReviewEligibilityService.php
@@ -5,6 +5,7 @@ use App\Models\User;
 use App\Models\Reservation;
 use App\Models\TripReservation;
 use App\Models\TransportReservation;
+use App\Models\ActivityReservation;
 use Illuminate\Database\Eloquent\Model;
 
 
@@ -48,6 +49,12 @@ class ReviewEligibilityService
                 )
                 ->exists(),
 
+            'activity' => ActivityReservation::where('user_id', $user->id)
+                ->where('activity_id', $id)
+                ->where('status', 'confirmed')
+                ->where('activity_date', '<', now())
+                ->exists(),
+
             default => false,
         };
     }
@@ -81,6 +88,13 @@ class ReviewEligibilityService
                 ->where('status', 'completed')
                 ->whereHas('trip', fn($q) => $q->where('assigned_guide_id', $reviewableId))
                 ->whereHas('schedule', fn($q) => $q->where('end_date', '<', now()))
+                ->first(),
+
+            'activity' => ActivityReservation::whereKey($reservationId)
+                ->where('user_id', $user->id)
+                ->where('activity_id', $reviewableId)
+                ->where('status', 'confirmed')
+                ->where('activity_date', '<', now())
                 ->first(),
 
             default => null,

--- a/database/migrations/2026_04_29_000001_add_activity_review_notification_sent_to_activity_reservations_table.php
+++ b/database/migrations/2026_04_29_000001_add_activity_review_notification_sent_to_activity_reservations_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('activity_reservations', function (Blueprint $table) {
+            if (! Schema::hasColumn('activity_reservations', 'activity_review_notification_sent')) {
+                $table->boolean('activity_review_notification_sent')->default(false)->after('status');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('activity_reservations', function (Blueprint $table) {
+            if (Schema::hasColumn('activity_reservations', 'activity_review_notification_sent')) {
+                $table->dropColumn('activity_review_notification_sent');
+            }
+        });
+    }
+};

--- a/resources/views/activities/show.blade.php
+++ b/resources/views/activities/show.blade.php
@@ -34,6 +34,17 @@
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg>
           {{$activity->address}}
       </div>
+      <div style="margin-top:12px;display:flex;gap:12px;align-items:center;flex-wrap:wrap;">
+        <a href="{{ route('activities.reviews.index', $activity->id) }}" class="book-btn" style="padding:10px 16px;">
+          View Reviews
+        </a>
+        @if($canReview && $reviewReservation)
+        <a href="{{ route('reviews.create', ['type' => 'activity', 'id' => $activity->id, 'reservation_id' => $reviewReservation->id]) }}" class="book-btn" style="padding:10px 16px;">
+          Leave Review
+        </a>
+        @endif
+      </div>
+
     </div>
     <div class="hero-price-box">
       <div class="price-label">Start from </div>
@@ -143,8 +154,8 @@
         <div class="stat-icon">
           <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#3b82c4" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
         </div>
-        <div class="stat-number">4.9</div>
-        <div class="stat-desc">User Rating </div>
+        <div class="stat-number">⭐ {{ number_format($averageRating ?? 0, 1) }}</div>
+        <div class="stat-desc">({{ $reviewsCount }}) Reviews</div>
       </div>
     </div>
 

--- a/resources/views/reviews/activity-index.blade.php
+++ b/resources/views/reviews/activity-index.blade.php
@@ -1,0 +1,99 @@
+<x-app-layout>
+    @push('styles')
+    <link rel="stylesheet" href="{{ asset('css/transport.css') }}">
+    <link rel="stylesheet" href="{{ asset('css/vehicles.css') }}">
+
+    <style>
+        .reviews-wrap{
+            max-width:900px;
+            margin:40px auto;
+            padding:0 16px;
+        }
+
+        .review-card{
+            background:#fff;
+            border-radius:14px;
+            padding:18px;
+            margin-bottom:14px;
+            box-shadow:0 4px 12px rgba(0,0,0,0.08);
+            transition:.2s;
+        }
+
+        .review-card:hover{
+            transform:translateY(-2px);
+        }
+
+        .review-top{
+            display:flex;
+            justify-content:space-between;
+            align-items:center;
+            margin-bottom:8px;
+        }
+
+        .user-name{
+            font-weight:600;
+            color:#111827;
+        }
+
+        .date{
+            font-size:12px;
+            color:#9ca3af;
+        }
+
+        .rating{
+            color:#f59e0b;
+            font-size:14px;
+            margin-bottom:6px;
+        }
+
+        .review-text{
+            color:#374151;
+            font-size:14px;
+            line-height:1.6;
+        }
+
+        .empty{
+            text-align:center;
+            color:#9ca3af;
+            padding:40px;
+        }
+    </style>
+    @endpush
+
+    <div class="reviews-wrap">
+    
+        <h1 style="font-size:22px;font-weight:700;margin-bottom:20px;">
+            Reviews for {{ $activity->name }}
+        </h1>
+    
+        @forelse($reviews as $review)
+            <div class="review-card">
+    
+                <div class="review-top">
+                    <div class="user-name">
+                        {{ $review->user?->full_name ?? 'Anonymous' }}
+                    </div>
+    
+                    <div class="date">
+                        {{ $review->created_at->format('d M Y') }}
+                    </div>
+                </div>
+    
+                <div class="rating">
+                    @for($i=0; $i < 5; $i++)
+                        <span style="color:{{ $i < $review->rating ? '#f59e0b' : '#e5e7eb' }}">★</span>
+                    @endfor
+                </div>
+    
+                <div class="review-text">
+                    {{ $review->review }}
+                </div>
+    
+            </div>
+        @empty
+            <div class="empty">No reviews yet.</div>
+        @endforelse
+    
+    </div>
+    
+    </x-app-layout>

--- a/resources/views/reviews/admin-index.blade.php
+++ b/resources/views/reviews/admin-index.blade.php
@@ -24,6 +24,7 @@
                 <option value="hotel" @selected(request('type')=='hotel')>Hotel</option>
                 <option value="trip" @selected(request('type')=='trip')>Trip</option>
                 <option value="guide" @selected(request('type')=='guide')>Guide</option>
+                <option value="activity" @selected(request('type')=='activity')>Activity</option>
                 <option value="driver" @selected(request('type')=='driver')>Driver</option>
             </select>
         </div>
@@ -111,7 +112,7 @@
                             {{-- Item --}}
                             <td class="px-6 py-4 whitespace-nowrap">
                                 <div class="text-sm text-gray-900">
-                                    {{ $review->reviewable->name ?? $review->reviewable->title ?? '—' }}
+                                    {{ $review->reviewable?->name ?? $review->reviewable?->title ?? '—' }}
                                 </div>
                             </td>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -343,6 +343,9 @@ Route::get('/reviews/create', [ReviewController::class, 'create'])
 Route::get('/guide/{id}/reviews', [ReviewController::class, 'guideIndex'])
     ->name('reviews.guide');
 
+Route::get('/activities/{id}/reviews', [ReviewController::class, 'activityIndex'])
+    ->name('activities.reviews.index');
+
 Route::get('/destination/{id}/activities', [DestinationController::class, 'activities'])->name('destination.activities');
 Route::get('/destination/{id}/trips', [DestinationController::class, 'trips'])->name('destination.trips');
 


### PR DESCRIPTION
### Motivation

- Enable users to submit and view reviews for activities and trigger review-request notifications after activity completion.
- Surface activity ratings and reviews on the activity detail page and provide a dedicated reviews index for activities.

### Description

- Added activity review relationships and helpers by introducing `reviews()` and `getAverageRatingAttribute()` on `App\Models\Activity` and updated `ActivityReservation` to include `activity_review_notification_sent` in `$fillable`.
- Implemented review eligibility and reservation resolution for activities in `App\Services\Review\ReviewEligibilityService` and updated `StoreReviewRequest` to accept `activity` as a valid review `type`.
- Added activity handling to the review lifecycle: updated `ReviewController` to support storing and listing activity reviews, added `activityIndex` and extended `store` logic to resolve `Activity` models, and registered a route `activities/{id}/reviews` in `routes/web.php`.
- Implemented UI and notification changes by updating `ActivityController::show` to include reviews, average rating, and `canReview` checks using `ReviewEligibilityService`, added `resources/views/reviews/activity-index.blade.php`, added review links to `resources/views/activities/show.blade.php`, and extended `SendReviewRequestNotification` to resolve activity names.
- Added background processing for activity review notifications by updating `CheckReviewableCompletions` to call `checkActivities()` and created a migration `2026_04_29_000001_add_activity_review_notification_sent_to_activity_reservations_table.php` to add the `activity_review_notification_sent` column.

### Testing

- Ran the existing test suite with `phpunit` against the application after the changes and observed all tests passing.
- No new automated tests were added for activity reviews in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f15fa01e80832f91dcacfdfbf06338)