### PR TITLE
Refactor AiTrip TripService into focused service classes

### DIFF
--- a/app/Services/AiTrip/TripBasicsService.php
+++ b/app/Services/AiTrip/TripBasicsService.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Services\AiTrip;
+
+use App\Models\Trip;
+use Illuminate\Support\Facades\DB;
+
+class TripBasicsService
+{
+    public function saveBasics(Trip $trip, array $payload): void
+    {
+        $destinationIds = array_values(array_unique(array_map('intval', $payload['destination_ids'])));
+        $primaryDestinationId = (int) $payload['destination_id'];
+
+        if (! in_array($primaryDestinationId, $destinationIds, true)) {
+            array_unshift($destinationIds, $primaryDestinationId);
+        }
+
+        $destinationIds = array_values(array_unique([$primaryDestinationId, ...$destinationIds]));
+
+        DB::transaction(function () use ($trip, $payload, $destinationIds, $primaryDestinationId) {
+            $trip->update(
+                collect($payload)
+                    ->except('destination_ids')
+                    ->put('destination_id', $primaryDestinationId)
+                    ->put('status', 'draft')
+                    ->all()
+            );
+
+            $this->syncDestinations($trip, $destinationIds);
+        });
+    }
+
+    public function syncDestinations(Trip $trip, array $destinationIds): void
+    {
+        $trip->itineraryDestinations()->sync(
+            collect($destinationIds)->values()->mapWithKeys(fn (int $destinationId, int $index) => [
+                $destinationId => ['sort_order' => $index + 1],
+            ])->all()
+        );
+    }
+}

--- a/app/Services/AiTrip/TripCreationService.php
+++ b/app/Services/AiTrip/TripCreationService.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Services\AiTrip;
+
+use App\Models\DayActivity;
+use App\Models\Trip;
+use App\Models\TripDay;
+use App\Models\TripPackage;
+use App\Models\TripPackageHotel;
+use App\Services\GroqTripPlannerService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class TripCreationService
+{
+    public function __construct(
+        protected GroqTripPlannerService $groqService,
+        protected TripBasicsService $tripBasicsService,
+        protected TripDaysService $tripDaysService,
+        protected TripSlugService $tripSlugService,
+        protected TripPackagesService $tripPackagesService
+    )
+    {
+    }
+
+    public function createFromAi(array $payload): ?Trip
+    {
+        $payload['destination_ids'] = array_values(array_unique(array_map('intval', $payload['destination_ids'])));
+        $payload['categories'] = array_values(array_unique($payload['categories']));
+        $language = $payload['language'] ?? 'en';
+
+        $plan = $this->groqService->generateTripPlan($payload, $language);
+
+        if (! $plan) {
+            return null;
+        }
+
+        return DB::transaction(function () use ($payload, $plan) {
+            $name = Str::limit($plan['trip_name'] ?: $payload['description'], 120, '');
+            $slugBase = Str::slug($name ?: 'ai-trip');
+            $primaryDestinationId = (int) $payload['destination_ids'][0];
+            $trip = Trip::create([
+                'destination_id' => $primaryDestinationId,
+                'name' => $name,
+                'slug' => $this->tripSlugService->nextUniqueSlug($slugBase),
+                'description' => $plan['trip_description'] ?? null,
+                'duration_days' => (int) $payload['duration'],
+                'category' => implode(',', $payload['categories']),
+                'max_participants' => (int) $payload['max_participants'],
+                'meeting_point_description' => null,
+                'meeting_point_address' => null,
+                'is_ai_generated' => true,
+                'ai_prompt' => $payload['description'],
+                'status' => 'draft',
+            ]);
+
+            $this->tripBasicsService->syncDestinations($trip, $payload['destination_ids']);
+            $this->tripDaysService->createDaysAndActivities($trip, $plan['days'] ?? []);
+            $this->bootstrapPackageFromAiPlan($trip);
+            return $trip;
+        });
+    }
+
+    protected function bootstrapPackageFromAiPlan(Trip $trip): void
+    {
+        if ($trip->packages()->exists()) {
+            return;
+        }
+
+        $package = TripPackage::create([
+            'trip_id' => $trip->id,
+            'name' => 'Standard Package',
+            'price' => 0,
+        ]);
+
+        $hotelIds = $this->tripPackagesService->canonicalHotelIdsFromDays($trip);
+        foreach ($hotelIds as $hotelId) {
+            TripPackageHotel::create([
+                'trip_package_id' => $package->id,
+                'hotel_id' => $hotelId,
+            ]);
+        }
+    }
+}

--- a/app/Services/AiTrip/TripDaysService.php
+++ b/app/Services/AiTrip/TripDaysService.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Services\AiTrip;
+
+use App\Models\DayActivity;
+use App\Models\Trip;
+use App\Models\TripDay;
+use App\Models\TripPackage;
+use App\Models\TripPackageHotel;
+use Illuminate\Support\Facades\DB;
+
+class TripDaysService
+{
+    public function __construct(protected TripPackagesService $tripPackagesService)
+    {
+    }
+
+    public function saveDaysActivities(Trip $trip, array $payload): void
+    {
+        DB::transaction(function () use ($trip, $payload) {
+            foreach ($payload['days'] as $dayPayload) {
+                $tripDay = TripDay::query()->updateOrCreate(
+                    ['trip_id' => $trip->id, 'day_number' => (int) $dayPayload['day_number']],
+                    [
+                        'title' => $dayPayload['title'] ?? null,
+                        'description' => $dayPayload['description'] ?? null,
+                        'hotel_id' => $dayPayload['hotel_id'] ?? null,
+                    ]
+                );
+
+                $sentActivityIds = [];
+
+                foreach (($dayPayload['activities'] ?? []) as $activityPayload) {
+                    if (empty($activityPayload['activity_id'])) {
+                        continue;
+                    }
+
+                    $activity = DayActivity::query()->updateOrCreate(
+                        [
+                            'id' => $activityPayload['id'] ?? null,
+                            'trip_day_id' => $tripDay->id,
+                        ],
+                        $this->dayActivityAttributes($tripDay->id, $activityPayload)
+                    );
+
+                    $sentActivityIds[] = $activity->id;
+                }
+
+                if (! empty($sentActivityIds)) {
+                    $tripDay->activities()->whereNotIn('id', $sentActivityIds)->delete();
+                } else {
+                    $tripDay->activities()->delete();
+                }
+            }
+
+            $canonicalHotelIds = $this->tripPackagesService->canonicalHotelIdsFromDays($trip->fresh('days'));
+            $trip->packages()->with('packageHotels')->get()->each(function (TripPackage $package) use ($canonicalHotelIds) {
+                $payload = $package->packageHotels
+                    ->map(fn (TripPackageHotel $packageHotel) => [
+                        'hotel_id' => $packageHotel->hotel_id,
+                        'room_type' => $packageHotel->room_type,
+                        'meal_plan' => $packageHotel->meal_plan,
+                        'amenities' => is_array($packageHotel->amenities) ? implode(', ', $packageHotel->amenities) : '',
+                        'notes' => $packageHotel->notes,
+                    ])
+                    ->values()
+                    ->all();
+
+                $this->tripPackagesService->syncPackageHotelsFromDays($package, $payload, $canonicalHotelIds);
+            });
+        });
+    }
+
+    public function createDaysAndActivities(Trip $trip, array $days): void
+    {
+        foreach ($days as $day) {
+            $tripDay = TripDay::create([
+                'trip_id' => $trip->id,
+                'day_number' => (int) $day['day_number'],
+                'title' => $day['title'],
+                'description' => $day['description'],
+                'highlights' => [],
+                'hotel_id' => $day['hotel_id'] ?? null,
+            ]);
+
+            foreach ($day['activities'] as $activity) {
+                DayActivity::query()->updateOrCreate(
+                    [
+                        'trip_day_id' => $tripDay->id,
+                        'activity_id' => (int) ($activity['activity_id'] ?? 0),
+                    ],
+                    $this->dayActivityAttributes($tripDay->id, $activity)
+                );
+            }
+        }
+    }
+
+    public function dayActivityAttributes(int $tripDayId, array $activityPayload): array
+    {
+        return [
+            'trip_day_id' => $tripDayId,
+            'activity_id' => (int) ($activityPayload['activity_id'] ?? 0),
+            'start_time' => $activityPayload['start_time'] ?? null,
+            'end_time' => $activityPayload['end_time'] ?? null,
+            'notes' => $activityPayload['notes'] ?? null,
+        ];
+    }
+}

--- a/app/Services/AiTrip/TripMediaService.php
+++ b/app/Services/AiTrip/TripMediaService.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Services\AiTrip;
+
+use App\Models\Trip;
+use App\Models\TripImage;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+class TripMediaService
+{
+    public function saveImages(Trip $trip, array $payload, ?UploadedFile $coverImageFile = null, array $imageFiles = []): void
+    {
+        DB::transaction(function () use ($trip, $payload, $coverImageFile, $imageFiles) {
+            $trip->images()->delete();
+
+            $coverImagePath = $payload['cover_existing_path'] ?? null;
+            if ($coverImageFile) {
+                $coverImagePath = '/storage/' . Storage::disk('public')->put('trips', $coverImageFile);
+            }
+
+            if (! empty($coverImagePath)) {
+                TripImage::create([
+                    'trip_id' => $trip->id,
+                    'image_path' => $coverImagePath,
+                    'is_cover' => true,
+                ]);
+            }
+
+            foreach (($payload['images'] ?? []) as $index => $imagePayload) {
+                $imagePath = $imagePayload['existing_path'] ?? null;
+
+                if (($imageFiles[$index]['image_file'] ?? null) instanceof UploadedFile) {
+                    $imagePath = '/storage/' . Storage::disk('public')->put('trips', $imageFiles[$index]['image_file']);
+                }
+
+                if (blank($imagePath)) {
+                    continue;
+                }
+
+                TripImage::create([
+                    'trip_id' => $trip->id,
+                    'image_path' => $imagePath,
+                    'is_cover' => false,
+                ]);
+            }
+        });
+    }
+}

--- a/app/Services/AiTrip/TripPackagesService.php
+++ b/app/Services/AiTrip/TripPackagesService.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Services\AiTrip;
+
+use App\Models\Trip;
+use App\Models\TripExclude;
+use App\Models\TripHighlight;
+use App\Models\TripInclude;
+use App\Models\TripPackage;
+use App\Models\TripPackageHotel;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class TripPackagesService
+{
+    public function savePackages(Trip $trip, array $payload): void
+    {
+        DB::transaction(function () use ($trip, $payload) {
+            $keepPackageIds = [];
+            $canonicalHotelIds = $this->canonicalHotelIdsFromDays($trip);
+
+            foreach (($payload['packages'] ?? []) as $packagePayload) {
+                if (blank($packagePayload['name'] ?? null) && blank($packagePayload['price'] ?? null)) {
+                    continue;
+                }
+
+                $package = TripPackage::query()->updateOrCreate(
+                    [
+                        'id' => $packagePayload['id'] ?? null,
+                        'trip_id' => $trip->id,
+                    ],
+                    [
+                        'name' => $packagePayload['name'] ?? 'Package',
+                        'price' => $packagePayload['price'] ?? 0,
+                    ]
+                );
+
+                $keepPackageIds[] = $package->id;
+                $this->syncPackageTextBlocks($package, $packagePayload);
+                $this->syncPackageHotelsFromDays($package, $packagePayload['hotels'] ?? [], $canonicalHotelIds);
+            }
+
+            $trip->packages()->whereNotIn('id', $keepPackageIds ?: [0])->delete();
+        });
+    }
+
+    public function syncPackageHotelsFromDays(TripPackage $package, array $hotelPayloads, array $canonicalHotelIds): void
+    {
+        $payloadByHotelId = collect($hotelPayloads)
+            ->filter(fn ($hotelPayload) => ! empty($hotelPayload['hotel_id']))
+            ->keyBy(fn ($hotelPayload) => (int) $hotelPayload['hotel_id']);
+
+        $payloadByIndex = collect($hotelPayloads)->values();
+
+        $package->packageHotels()->delete();
+
+        foreach ($canonicalHotelIds as $index => $hotelId) {
+            $matchedPayload = $payloadByHotelId->get($hotelId) ?? $payloadByIndex->get($index, []);
+
+            TripPackageHotel::create([
+                'trip_package_id' => $package->id,
+                'hotel_id' => $hotelId,
+                'room_type' => $matchedPayload['room_type'] ?? null,
+                'meal_plan' => $matchedPayload['meal_plan'] ?? null,
+                'amenities' => collect(explode(',', (string) ($matchedPayload['amenities'] ?? '')))
+                    ->map(fn ($item) => trim($item))
+                    ->filter()
+                    ->values()
+                    ->all(),
+                'notes' => $matchedPayload['notes'] ?? null,
+            ]);
+        }
+    }
+
+    public function syncPackageTextBlocks(TripPackage $package, array $payload): void
+    {
+        $package->includes()->delete();
+        collect($this->normalizeRepeaterInput($payload['includes'] ?? []))
+            ->map(fn ($line) => trim($line))
+            ->filter()
+            ->each(fn ($line) => TripInclude::create(['trip_package_id' => $package->id, 'content' => $line]));
+
+        $package->excludes()->delete();
+        collect($this->normalizeRepeaterInput($payload['excludes'] ?? []))
+            ->map(fn ($line) => trim($line))
+            ->filter()
+            ->each(fn ($line) => TripExclude::create(['trip_package_id' => $package->id, 'content' => $line]));
+
+        $package->highlights()->delete();
+        collect($this->normalizeRepeaterInput($payload['highlights'] ?? []))
+            ->map(fn ($line) => trim($line))
+            ->filter()
+            ->each(fn ($line) => TripHighlight::create([
+                'trip_package_id' => $package->id,
+                'title' => Str::limit($line, 255),
+                'description' => $line,
+            ]));
+    }
+
+    public function canonicalHotelIdsFromDays(Trip $trip): array
+    {
+        return $trip->days()
+            ->orderBy('day_number')
+            ->whereNotNull('hotel_id')
+            ->pluck('hotel_id')
+            ->map(fn ($hotelId) => (int) $hotelId)
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    protected function normalizeRepeaterInput(mixed $value): array
+    {
+        if (is_array($value)) {
+            return array_values($value);
+        }
+
+        if (is_string($value)) {
+            return explode(PHP_EOL, $value);
+        }
+
+        return [];
+    }
+}

--- a/app/Services/AiTrip/TripScheduleService.php
+++ b/app/Services/AiTrip/TripScheduleService.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Services\AiTrip;
+
+use App\Models\Trip;
+use App\Models\TripSchedule;
+use Illuminate\Support\Facades\DB;
+
+class TripScheduleService
+{
+    public function saveSchedules(Trip $trip, array $payload): void
+    {
+        DB::transaction(function () use ($trip, $payload) {
+            $keepIds = [];
+
+            foreach (($payload['schedules'] ?? []) as $schedulePayload) {
+                $schedule = TripSchedule::query()->updateOrCreate(
+                    ['id' => $schedulePayload['id'] ?? null, 'trip_id' => $trip->id],
+                    [
+                        'start_date' => $schedulePayload['start_date'],
+                        'end_date' => $schedulePayload['end_date'],
+                        'booking_deadline' => $schedulePayload['booking_deadline'] ?? null,
+                        'available_seats' => $schedulePayload['available_seats'] ?? null,
+                        'price_modifier' => $schedulePayload['price_modifier'] ?? 0,
+                        'status' => $schedulePayload['status'] ?? 'available',
+                    ]
+                );
+
+                $keepIds[] = $schedule->id;
+            }
+
+            $trip->schedules()->whereNotIn('id', $keepIds ?: [0])->delete();
+        });
+    }
+}

--- a/app/Services/AiTrip/TripService.php
+++ b/app/Services/AiTrip/TripService.php
@@ -2,423 +2,56 @@
 
 namespace App\Services\AiTrip;
 
-use App\Jobs\TripStaffing\StartTripStaffingJob;
-use App\Models\DayActivity;
 use App\Models\Trip;
-use App\Models\TripDay;
-use App\Models\TripExclude;
-use App\Models\TripHighlight;
-use App\Models\TripImage;
-use App\Models\TripInclude;
-use App\Models\TripPackage;
-use App\Models\TripPackageHotel;
-use App\Models\TripSchedule;
-use App\Services\GroqTripPlannerService;
-use App\Services\Trip\TripStateManager;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
 
 class TripService
 {
     public function __construct(
-        protected GroqTripPlannerService $groqService,
-        protected TripStateManager $tripStateManager
+        protected TripCreationService $tripCreationService,
+        protected TripBasicsService $tripBasicsService,
+        protected TripDaysService $tripDaysService,
+        protected TripPackagesService $tripPackagesService,
+        protected TripMediaService $tripMediaService,
+        protected TripScheduleService $tripScheduleService,
+        protected TripStateService $tripStateService,
+        protected TripSlugService $tripSlugService
     )
     {
     }
 
-    //input sanitizing
     public function createFromAi(array $payload): ?Trip
     {
-        $payload['destination_ids'] = array_values(array_unique(array_map('intval', $payload['destination_ids']))); //ids to numbers, prevent dupliaction,sorting
-        $payload['categories'] = array_values(array_unique($payload['categories']));
-        $language = $payload['language'] ?? 'en';
-
-        $plan = $this->groqService->generateTripPlan($payload, $language);
-
-        if (! $plan) {
-            return null;
-        }
-
-        return DB::transaction(function () use ($payload, $plan) {
-            $name = Str::limit($plan['trip_name'] ?: $payload['description'], 120, '');
-            $slugBase = Str::slug($name ?: 'ai-trip');
-            $primaryDestinationId = (int) $payload['destination_ids'][0];
-            $trip = Trip::create([
-                'destination_id' => $primaryDestinationId,
-                'name' => $name,
-                'slug' => $this->nextUniqueSlug($slugBase), //unique url name
-                'description' => $plan['trip_description'] ?? null,
-                'duration_days' => (int) $payload['duration'],
-                'category' => implode(',', $payload['categories']),
-                'max_participants' => (int) $payload['max_participants'],
-                'meeting_point_description' => null,
-                'meeting_point_address' => null,
-                'is_ai_generated' => true,
-                'ai_prompt' => $payload['description'],
-                'status' => 'draft',
-            ]);
-
-            $this->syncDestinations($trip, $payload['destination_ids']);
-            $this->createDaysAndActivities($trip, $plan['days'] ?? []);
-            $this->bootstrapPackageFromAiPlan($trip);
-            return $trip;
-        });
+        return $this->tripCreationService->createFromAi($payload);
     }
-
 
     public function saveBasics(Trip $trip, array $payload): void
     {
-        $destinationIds = array_values(array_unique(array_map('intval', $payload['destination_ids'])));
-        $primaryDestinationId = (int) $payload['destination_id'];
-
-        //check primary destination is in array
-        if (! in_array($primaryDestinationId, $destinationIds, true)) {
-            array_unshift($destinationIds, $primaryDestinationId); 
-        }
-
-        $destinationIds = array_values(array_unique([$primaryDestinationId, ...$destinationIds]));
-
-        DB::transaction(function () use ($trip, $payload, $destinationIds, $primaryDestinationId) {
-            $trip->update(
-                collect($payload)
-                    ->except('destination_ids')
-                    ->put('destination_id', $primaryDestinationId)
-                    ->put('status', 'draft')
-                    ->all()
-            );
-
-            //m-m relationship
-            $this->syncDestinations($trip, $destinationIds);
-        });
+        $this->tripBasicsService->saveBasics($trip, $payload);
     }
 
     public function saveDaysActivities(Trip $trip, array $payload): void
     {
-        DB::transaction(function () use ($trip, $payload) {
-            foreach ($payload['days'] as $dayPayload) {
-                $tripDay = TripDay::query()->updateOrCreate(
-                    ['trip_id' => $trip->id, 'day_number' => (int) $dayPayload['day_number']],
-                    [
-                        'title' => $dayPayload['title'] ?? null,
-                        'description' => $dayPayload['description'] ?? null,
-                        'hotel_id' => $dayPayload['hotel_id'] ?? null,
-                    ]
-                );
-
-                $sentActivityIds = [];
-
-                foreach (($dayPayload['activities'] ?? []) as $activityPayload) {
-                    if (empty($activityPayload['activity_id'])) { //ignore activity without id
-                        continue;
-                    }
-
-                    $activity = DayActivity::query()->updateOrCreate(
-                        [
-                            'id' => $activityPayload['id'] ?? null,
-                            'trip_day_id' => $tripDay->id,
-                        ],
-                        $this->dayActivityAttributes($tripDay->id, $activityPayload)
-                    );
-
-                    $sentActivityIds[] = $activity->id; //to know activities remains after update 
-                }
-
-                //delete not sended activities
-                if (! empty($sentActivityIds)) {
-                    $tripDay->activities()->whereNotIn('id', $sentActivityIds)->delete(); 
-                } else { 
-                    $tripDay->activities()->delete();   //No activities at all
-                }
-            }
-
-            //get all hotels in trip
-            $canonicalHotelIds = $this->canonicalHotelIdsFromDays($trip->fresh('days')); //latest trip instance from db
-            $trip->packages()->with('packageHotels')->get()->each(function (TripPackage $package) use ($canonicalHotelIds) {
-                $payload = $package->packageHotels
-                    ->map(fn (TripPackageHotel $packageHotel) => [
-                        'hotel_id' => $packageHotel->hotel_id,
-                        'room_type' => $packageHotel->room_type,
-                        'meal_plan' => $packageHotel->meal_plan,
-                        'amenities' => is_array($packageHotel->amenities) ? implode(', ', $packageHotel->amenities) : '',
-                        'notes' => $packageHotel->notes,
-                    ])
-                    ->values()
-                    ->all();
-
-                $this->syncPackageHotelsFromDays($package, $payload, $canonicalHotelIds);
-            });
-        });
+        $this->tripDaysService->saveDaysActivities($trip, $payload);
     }
 
     public function savePackages(Trip $trip, array $payload): void
     {
-        DB::transaction(function () use ($trip, $payload) { 
-            $keepPackageIds = [];
-            $canonicalHotelIds = $this->canonicalHotelIdsFromDays($trip); //get hotels from days
-
-            foreach (($payload['packages'] ?? []) as $packagePayload) {
-                if (blank($packagePayload['name'] ?? null) && blank($packagePayload['price'] ?? null)) {
-                    continue;
-                }
-
-                $package = TripPackage::query()->updateOrCreate(
-                    [
-                        'id' => $packagePayload['id'] ?? null,
-                        'trip_id' => $trip->id,
-                    ],
-                    [
-                        'name' => $packagePayload['name'] ?? 'Package',
-                        'price' => $packagePayload['price'] ?? 0,
-                    ]
-                );
-
-                $keepPackageIds[] = $package->id;
-                $this->syncPackageTextBlocks($package, $packagePayload); //package test content (include,exclude)
-                $this->syncPackageHotelsFromDays($package, $packagePayload['hotels'] ?? [], $canonicalHotelIds); //package hotels=days hotels
-            }
-
-            $trip->packages()->whereNotIn('id', $keepPackageIds ?: [0])->delete();
-        });
+        $this->tripPackagesService->savePackages($trip, $payload);
     }
 
     public function saveSchedules(Trip $trip, array $payload): void
     {
-        DB::transaction(function () use ($trip, $payload) {
-            $keepIds = [];
-
-            foreach (($payload['schedules'] ?? []) as $schedulePayload) {
-                $schedule = TripSchedule::query()->updateOrCreate(
-                    ['id' => $schedulePayload['id'] ?? null, 'trip_id' => $trip->id],
-                    [
-                        'start_date' => $schedulePayload['start_date'],
-                        'end_date' => $schedulePayload['end_date'],
-                        'booking_deadline' => $schedulePayload['booking_deadline'] ?? null,
-                        'available_seats' => $schedulePayload['available_seats'] ?? null,
-                        'price_modifier' => $schedulePayload['price_modifier'] ?? 0,
-                        'status' => $schedulePayload['status'] ?? 'available',
-                    ]
-                );
-
-                $keepIds[] = $schedule->id;
-            }
-
-            $trip->schedules()->whereNotIn('id', $keepIds ?: [0])->delete();
-        });
+        $this->tripScheduleService->saveSchedules($trip, $payload);
     }
 
     public function saveImages(Trip $trip, array $payload, ?UploadedFile $coverImageFile = null, array $imageFiles = []): void
     {
-        DB::transaction(function () use ($trip, $payload, $coverImageFile, $imageFiles) {
-            $trip->images()->delete();
-
-            $coverImagePath = $payload['cover_existing_path'] ?? null;
-            if ($coverImageFile) {
-                $coverImagePath = '/storage/' . Storage::disk('public')->put('trips', $coverImageFile);
-            }
-
-            if (! empty($coverImagePath)) {
-                TripImage::create([
-                    'trip_id' => $trip->id,
-                    'image_path' => $coverImagePath,
-                    'is_cover' => true,
-                ]);
-            }
-
-            foreach (($payload['images'] ?? []) as $index => $imagePayload) {
-                $imagePath = $imagePayload['existing_path'] ?? null;
-
-                if (($imageFiles[$index]['image_file'] ?? null) instanceof UploadedFile) {
-                    $imagePath = '/storage/' . Storage::disk('public')->put('trips', $imageFiles[$index]['image_file']);
-                }
-
-                if (blank($imagePath)) {
-                    continue;
-                }
-
-                TripImage::create([
-                    'trip_id' => $trip->id,
-                    'image_path' => $imagePath,
-                    'is_cover' => false,
-                ]);
-            }
-        });
+        $this->tripMediaService->saveImages($trip, $payload, $coverImageFile, $imageFiles);
     }
 
     public function confirmOverview(Trip $trip): void
     {
-        DB::transaction(function () use ($trip) {
-            $trip->refresh();
-
-            if ($trip->status === 'staffing_in_progress' || $trip->status === 'staffed' || $trip->status === 'published') {
-                return;
-            }
-
-            if ($trip->status === 'draft') {
-                $this->tripStateManager->transition($trip, 'ready_for_assignment');
-            }
-
-            if ($trip->fresh()->status === 'ready_for_assignment') {
-                StartTripStaffingJob::dispatch($trip->id)->afterCommit();
-            }
-        });
-    }
-
-    protected function createDaysAndActivities(Trip $trip, array $days): void
-    {
-        foreach ($days as $day) {
-            $tripDay = TripDay::create([
-                'trip_id' => $trip->id,
-                'day_number' => (int) $day['day_number'],
-                'title' => $day['title'],
-                'description' => $day['description'],
-                'highlights' => [],
-                'hotel_id' => $day['hotel_id'] ?? null,
-            ]);
-
-            foreach ($day['activities'] as $activity) {
-                DayActivity::query()->updateOrCreate(
-                    [
-                        'trip_day_id' => $tripDay->id,
-                        'activity_id' => (int) ($activity['activity_id'] ?? 0),
-                    ],
-                    $this->dayActivityAttributes($tripDay->id, $activity)
-                );
-            }
-        }
-    }
-
-    protected function syncPackageTextBlocks(TripPackage $package, array $payload): void
-    {
-        $package->includes()->delete();
-        collect($this->normalizeRepeaterInput($payload['includes'] ?? []))
-            ->map(fn ($line) => trim($line))
-            ->filter()
-            ->each(fn ($line) => TripInclude::create(['trip_package_id' => $package->id, 'content' => $line]));
-
-        $package->excludes()->delete();
-        collect($this->normalizeRepeaterInput($payload['excludes'] ?? []))
-            ->map(fn ($line) => trim($line))
-            ->filter()
-            ->each(fn ($line) => TripExclude::create(['trip_package_id' => $package->id, 'content' => $line]));
-
-        $package->highlights()->delete();
-        collect($this->normalizeRepeaterInput($payload['highlights'] ?? []))
-            ->map(fn ($line) => trim($line))
-            ->filter()
-            ->each(fn ($line) => TripHighlight::create([
-                'trip_package_id' => $package->id,
-                'title' => Str::limit($line, 255),
-                'description' => $line,
-            ]));
-    }
-
-    protected function syncDestinations(Trip $trip, array $destinationIds): void
-    {
-        $trip->itineraryDestinations()->sync(
-            collect($destinationIds)->values()->mapWithKeys(fn (int $destinationId, int $index) => [
-                $destinationId => ['sort_order' => $index + 1],
-            ])->all()
-        );
-    }
-
-    protected function nextUniqueSlug(string $slugBase): string
-    {
-        $slug = $slugBase ?: 'ai-trip';
-        $counter = 1;
-
-        while (Trip::query()->where('slug', $slug)->exists()) {
-            $slug = $slugBase . '-' . $counter;
-            $counter++;
-        }
-
-        return $slug;
-    }
-
-    protected function bootstrapPackageFromAiPlan(Trip $trip): void
-    {
-        if ($trip->packages()->exists()) {
-            return;
-        }
-
-        $package = TripPackage::create([
-            'trip_id' => $trip->id,
-            'name' => 'Standard Package',
-            'price' => 0,
-        ]);
-
-        $hotelIds = $this->canonicalHotelIdsFromDays($trip);
-        foreach ($hotelIds as $hotelId) {
-            TripPackageHotel::create([
-                'trip_package_id' => $package->id,
-                'hotel_id' => $hotelId,
-            ]);
-        }
-    }
-
-    protected function canonicalHotelIdsFromDays(Trip $trip): array
-    {
-        return $trip->days()
-            ->orderBy('day_number')
-            ->whereNotNull('hotel_id')
-            ->pluck('hotel_id')
-            ->map(fn ($hotelId) => (int) $hotelId)
-            ->unique()
-            ->values()
-            ->all();
-    }
-
-    protected function syncPackageHotelsFromDays(TripPackage $package, array $hotelPayloads, array $canonicalHotelIds): void
-    {
-        $payloadByHotelId = collect($hotelPayloads)
-            ->filter(fn ($hotelPayload) => ! empty($hotelPayload['hotel_id']))
-            ->keyBy(fn ($hotelPayload) => (int) $hotelPayload['hotel_id']);
-
-        $payloadByIndex = collect($hotelPayloads)->values();
-
-        $package->packageHotels()->delete();
-
-        foreach ($canonicalHotelIds as $index => $hotelId) {
-            $matchedPayload = $payloadByHotelId->get($hotelId) ?? $payloadByIndex->get($index, []);
-
-            TripPackageHotel::create([
-                'trip_package_id' => $package->id,
-                'hotel_id' => $hotelId,
-                'room_type' => $matchedPayload['room_type'] ?? null,
-                'meal_plan' => $matchedPayload['meal_plan'] ?? null,
-                'amenities' => collect(explode(',', (string) ($matchedPayload['amenities'] ?? '')))
-                    ->map(fn ($item) => trim($item))
-                    ->filter()
-                    ->values()
-                    ->all(),
-                'notes' => $matchedPayload['notes'] ?? null,
-            ]);
-        }
-    }
-
-    protected function dayActivityAttributes(int $tripDayId, array $activityPayload): array
-    {
-        return [
-            'trip_day_id' => $tripDayId,
-            'activity_id' => (int) ($activityPayload['activity_id'] ?? 0),
-            'start_time' => $activityPayload['start_time'] ?? null,
-            'end_time' => $activityPayload['end_time'] ?? null,
-            'notes' => $activityPayload['notes'] ?? null,
-        ];
-    }
-
-    protected function normalizeRepeaterInput(mixed $value): array
-    {
-        if (is_array($value)) {
-            return array_values($value);
-        }
-
-        if (is_string($value)) {
-            return explode(PHP_EOL, $value);
-        }
-
-        return [];
+        $this->tripStateService->confirmOverview($trip);
     }
 }

--- a/app/Services/AiTrip/TripSlugService.php
+++ b/app/Services/AiTrip/TripSlugService.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Services\AiTrip;
+
+use App\Models\Trip;
+
+class TripSlugService
+{
+    public function nextUniqueSlug(string $slugBase): string
+    {
+        $slug = $slugBase ?: 'ai-trip';
+        $counter = 1;
+
+        while (Trip::query()->where('slug', $slug)->exists()) {
+            $slug = $slugBase . '-' . $counter;
+            $counter++;
+        }
+
+        return $slug;
+    }
+}

--- a/app/Services/AiTrip/TripStateService.php
+++ b/app/Services/AiTrip/TripStateService.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Services\AiTrip;
+
+use App\Jobs\TripStaffing\StartTripStaffingJob;
+use App\Models\Trip;
+use App\Services\Trip\TripStateManager;
+use Illuminate\Support\Facades\DB;
+
+class TripStateService
+{
+    public function __construct(protected TripStateManager $tripStateManager)
+    {
+    }
+
+    public function confirmOverview(Trip $trip): void
+    {
+        DB::transaction(function () use ($trip) {
+            $trip->refresh();
+
+            if ($trip->status === 'staffing_in_progress' || $trip->status === 'staffed' || $trip->status === 'published') {
+                return;
+            }
+
+            if ($trip->status === 'draft') {
+                $this->tripStateManager->transition($trip, 'ready_for_assignment');
+            }
+
+            if ($trip->fresh()->status === 'ready_for_assignment') {
+                StartTripStaffingJob::dispatch($trip->id)->afterCommit();
+            }
+        });
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce the size and responsibility of `App\Services\AiTrip\TripService` by moving cohesive responsibilities into smaller services for clearer separation of concerns. 
- Preserve all existing behavior, public APIs, DB queries, transactions and return types while making the implementation easier to maintain and test. 
- Prepare for dependency injection of focused services and easier evolvability without changing business logic. 

### Description
- Replaced the large `TripService` implementation with a thin coordinator that delegates to new services via constructor injection and preserves the same public methods (`createFromAi`, `saveBasics`, `saveDaysActivities`, `savePackages`, `saveSchedules`, `saveImages`, `confirmOverview`).
- Extracted creation logic into `TripCreationService` and kept `createFromAi` behaviour identical (payload sanitization, plan generation, transaction, slug lookup, destination sync, days/activities creation and package bootstrap). 
- Extracted basics, days, packages, media, schedules, state and slug responsibilities into `TripBasicsService`, `TripDaysService`, `TripPackagesService`, `TripMediaService`, `TripScheduleService`, `TripStateService`, and `TripSlugService` respectively, keeping original method names and internal logic unchanged. 
- Preserved all transactions, Eloquent queries, relationships and helpers (including repeater normalization and canonical hotel ID logic) so data flow and database behavior remain identical.

### Testing
- Ran PHP syntax checks across the refactored and new files with `php -l` for each service file, e.g. `php -l app/Services/AiTrip/TripService.php && php -l app/Services/AiTrip/TripCreationService.php && php -l app/Services/AiTrip/TripBasicsService.php && php -l app/Services/AiTrip/TripDaysService.php && php -l app/Services/AiTrip/TripPackagesService.php && php -l app/Services/AiTrip/TripMediaService.php && php -l app/Services/AiTrip/TripScheduleService.php && php -l app/Services/AiTrip/TripStateService.php && php -l app/Services/AiTrip/TripSlugService.php`, and all checks reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f563351c6c832f89db1159aea9bd12)