### PR TITLE
Driver ranking: add rating strategy, country filter and runtime strategy selection

### DIFF
--- a/app/Domain/TransportReservation/Ranking/RatingStrategy.php
+++ b/app/Domain/TransportReservation/Ranking/RatingStrategy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Domain\TransportReservation\Ranking;
+
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+class RatingStrategy implements DriverRankingStrategy
+{
+    public function rank(Collection $drivers): Collection
+    {
+        return $drivers->sortBy(function ($driver) {
+            $lastTripAt = $driver->last_trip_at;
+
+            if (!$lastTripAt) {
+                $lastTripTimestamp = now()->subYears(20)->timestamp;
+            } elseif ($lastTripAt instanceof \DateTimeInterface) {
+                $lastTripTimestamp = $lastTripAt->getTimestamp();
+            } else {
+                $lastTripTimestamp = Carbon::parse($lastTripAt)->timestamp;
+            }
+
+            $averageRating = $driver->average_rating;
+            $hasRating = $averageRating !== null;
+
+            return [
+                $hasRating ? 0 : 1,
+                $hasRating ? -1 * (float) $averageRating : 0,
+                (int) ($driver->total_trips_count ?? 0),
+                $lastTripTimestamp,
+            ];
+        })->values();
+    }
+}

--- a/app/Jobs/ProcessReservationDriverMatchingJob.php
+++ b/app/Jobs/ProcessReservationDriverMatchingJob.php
@@ -3,6 +3,8 @@
 namespace App\Jobs;
 
 use App\Domain\TransportReservation\DriverChain\SendToNextDriverHandler;
+use App\Domain\TransportReservation\Ranking\LastTripAndTripsCountStrategy;
+use App\Domain\TransportReservation\Ranking\RatingStrategy;
 use App\Models\TransportReservation;
 use App\Services\TransportReservation\DriverRankingService;
 use App\Services\TransportReservation\ReservationStateManager;
@@ -22,7 +24,7 @@ class ProcessReservationDriverMatchingJob implements ShouldQueue
     {
     }
 
-    public function handle(DriverRankingService $rankingService, ReservationStateManager $stateManager): void
+    public function handle(ReservationStateManager $stateManager): void
     {
         //get reservation
         $reservation = TransportReservation::find($this->reservationId);
@@ -35,6 +37,13 @@ class ProcessReservationDriverMatchingJob implements ShouldQueue
         if ($reservation->status === 'pending_payment') {
             $stateManager->transition($reservation, 'pending_driver');
         }
+
+        $preferredCategory = strtolower((string) $reservation->preferred_category);
+        $strategy = in_array($preferredCategory, ['vip', 'luxury'], true)
+            ? new RatingStrategy()
+            : new LastTripAndTripsCountStrategy();
+
+        $rankingService = new DriverRankingService($strategy);
 
         try {
             $rankedDriverIds = $rankingService->rankedDriverIdsForReservation($reservation);

--- a/app/Services/TransportReservation/DriverRankingService.php
+++ b/app/Services/TransportReservation/DriverRankingService.php
@@ -89,7 +89,20 @@ class DriverRankingService
             return [];
         }
 
-        $drivers = Driver::query()->whereIn("id", $driverIds)->get();
+        $drivers = Driver::query()->with('user:id,country')->whereIn("id", $driverIds)->get();
+
+        $pickupLocationParts = explode(',', (string) $reservation->pickup_location);
+        $pickupCountry = trim((string) end($pickupLocationParts));
+
+        if ($pickupCountry !== '') {
+            $drivers = $drivers->filter(function ($driver) use ($pickupCountry) {
+                return $driver->user?->country === $pickupCountry;
+            })->values();
+        }
+
+        if ($drivers->isEmpty()) {
+            return [];
+        }
 
         //ranking strategy
         return $this->strategy->rank($drivers)->pluck("id")->all();


### PR DESCRIPTION
### Motivation

- Introduce a rating-aware ranking mode for higher-end reservations to prefer drivers with ratings and recent activity.
- Restrict candidate drivers to those matching the reservation pickup country to avoid cross-country assignments.
- Allow runtime selection of ranking strategy based on reservation `preferred_category` so different categories use different ranking logic.

### Description

- Add `App\Domain\TransportReservation\Ranking\RatingStrategy` which implements `DriverRankingStrategy` and sorts drivers by presence of rating, descending `average_rating`, trips count, then last trip timestamp (treating missing last trip as very old).
- Change `ProcessReservationDriverMatchingJob` to select a ranking strategy at runtime (use `RatingStrategy` for `vip`/`luxury`, otherwise `LastTripAndTripsCountStrategy`) and instantiate `DriverRankingService` with that strategy instead of relying on DI for the service.
- Update `DriverRankingService` to eager-load `user:id,country` for drivers and to parse the reservation `pickup_location` country (last comma-separated part) and filter drivers by `user.country` when present, returning early if no drivers remain.
- Preserve existing shift and vehicle-overlap checks and return the ranked driver ids via the configured strategy with the final `pluck('id')->all()`.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce801d3f4832f9ecd77998e7d5e93)