### PR TITLE
Add Driver reviews page and listing Reviews buttons

### DIFF
--- a/app/Http/Controllers/ReviewController.php
+++ b/app/Http/Controllers/ReviewController.php
@@ -171,6 +171,18 @@ public function guideIndex(string $id)
     return view('reviews.guide-index', compact('guide', 'reviews', 'avg'));
 }
 
+
+public function driverIndex(string $id)
+{
+    $driver = Driver::with('user')->findOrFail($id);
+
+    $reviews = $driver->reviews()->with('user')->latest()->get();
+
+    $avg = $driver->average_rating;
+
+    return view('reviews.driver-index', compact('driver', 'reviews', 'avg'));
+}
+
 public function activityIndex(string $id)
 {
     $activity = Activity::with('reviews.user')->findOrFail($id);

--- a/app/Models/Driver.php
+++ b/app/Models/Driver.php
@@ -60,4 +60,9 @@ class Driver extends Model
     return round($this->reviews()->avg('rating') ?? 0, 1);
 }
 
+public function getReviewsCountAttribute()
+{
+    return $this->reviews()->count();
+}
+
 }

--- a/resources/views/driver/approvedindex.blade.php
+++ b/resources/views/driver/approvedindex.blade.php
@@ -221,6 +221,17 @@
                                    
                              </td>
 
+                                <td class="px-6 py-4 whitespace-nowrap  text-center">
+                                  <a href="{{ route('reviews.driver', $driver->id) }}">
+                                        <div class="inline-flex items-center gap-2">
+                                             <button class="order-btn edit-btn px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700">
+                                                  Reviews
+                                                    </button>
+                                        </div>
+                                    </a>
+                                   
+                             </td>
+
                                 <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                             <!--delete driver button-->
                                   <div class="flex items-center gap-4">

--- a/resources/views/guide/index.blade.php
+++ b/resources/views/guide/index.blade.php
@@ -139,7 +139,16 @@
                                  
                            </td>
 
-
+                             <td class="px-6 py-4 whitespace-nowrap  text-center">
+                                <a href="{{ route('reviews.guide', $guide->id) }}">
+                                      <div class="inline-flex items-center gap-2">
+                                           <button class="order-btn edit-btn px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700">
+                                                Reviews
+                                                  </button>
+                                      </div>
+                                  </a>
+                                 
+                           </td>
 
                                 <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                             <!--delete driver button-->

--- a/resources/views/reviews/driver-index.blade.php
+++ b/resources/views/reviews/driver-index.blade.php
@@ -1,0 +1,146 @@
+<x-app-layout>
+    @push('styles')
+    <link rel="stylesheet" href="{{ asset('css/transport.css') }}">
+    <link rel="stylesheet" href="{{ asset('css/vehicles.css') }}">
+
+    <style>
+        .reviews-wrap{
+            max-width:900px;
+            margin:40px auto;
+            padding:0 16px;
+        }
+
+        .header-box{
+            background: linear-gradient(135deg, #185FA5, #3FA7F5);
+            color:#fff;
+            padding:20px;
+            border-radius:14px;
+            margin-bottom:20px;
+        }
+
+        .header-box h1{
+            font-size:22px;
+            margin-bottom:6px;
+        }
+
+        .header-box p{
+            font-size:13px;
+            opacity:.9;
+        }
+
+        .rating-summary{
+            margin-top:10px;
+            font-size:14px;
+        }
+
+        .review-card{
+            background:#fff;
+            border-radius:14px;
+            padding:18px;
+            margin-bottom:14px;
+            box-shadow:0 4px 12px rgba(0,0,0,0.08);
+            transition:.2s;
+        }
+
+        .review-card:hover{
+            transform:translateY(-2px);
+        }
+
+        .review-top{
+            display:flex;
+            justify-content:space-between;
+            align-items:center;
+            margin-bottom:8px;
+        }
+
+        .user-name{
+            font-weight:600;
+            color:#111827;
+        }
+
+        .date{
+            font-size:12px;
+            color:#9ca3af;
+        }
+
+        .rating{
+            color:#f59e0b;
+            font-size:14px;
+            margin-bottom:6px;
+        }
+
+        .review-text{
+            color:#374151;
+            font-size:14px;
+            line-height:1.6;
+        }
+
+        .empty{
+            text-align:center;
+            color:#9ca3af;
+            padding:40px;
+        }
+
+        .stars-big{
+            font-size:18px;
+            margin-top:5px;
+        }
+    </style>
+    @endpush
+
+
+    <div class="reviews-wrap">
+
+        <div class="header-box">
+            <h1>Reviews for {{ $driver->user?->name }}</h1>
+
+            <p>{{ $driver->license_category ?? 'N/A' }} license category • Driver profile</p>
+
+            <div class="rating-summary">
+                @php $avg = $avg ?? 0; @endphp
+
+                <div class="stars-big">
+                    @for($i=1; $i<=5; $i++)
+                        <span style="color:{{ $i <= $avg ? '#fff' : 'rgba(255,255,255,0.4)' }}">★</span>
+                    @endfor
+                </div>
+
+                <div style="margin-top:4px;">
+                    Average rating: {{ number_format($avg,1) }} • {{ $driver->reviews_count }} reviews
+                </div>
+            </div>
+        </div>
+
+        @forelse($reviews as $review)
+            <div class="review-card">
+
+                <div class="review-top">
+                    <div class="user-name">
+                        {{ $review->user?->full_name ?? 'Anonymous' }}
+                    </div>
+
+                    <div class="date">
+                        {{ $review->created_at->format('d M Y') }}
+                    </div>
+                </div>
+
+                <div class="rating">
+                    @for($i=0; $i < 5; $i++)
+                        <span style="color:{{ $i < $review->rating ? '#f59e0b' : '#e5e7eb' }}">★</span>
+                    @endfor
+                </div>
+
+                <div class="review-text">
+                    {{ $review->review }}
+                </div>
+
+            </div>
+        @empty
+            <div class="empty">
+                No reviews yet for this driver.
+            </div>
+        @endforelse
+
+    </div>
+
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -335,6 +335,9 @@ Route::get('/reviews/create', [ReviewController::class, 'create'])
 Route::get('/guide/{id}/reviews', [ReviewController::class, 'guideIndex'])
     ->name('reviews.guide');
 
+Route::get('/driver/{id}/reviews', [ReviewController::class, 'driverIndex'])
+    ->name('reviews.driver');
+
 Route::get('/activities/{id}/reviews', [ReviewController::class, 'activityIndex'])
     ->name('activities.reviews.index');
 


### PR DESCRIPTION
### Motivation
- Drivers did not have a dedicated reviews page or a way to navigate to reviews from the listings, while Guides already had a reviews flow that should be reused. 
- Expose the same average-rating and total-review information for Drivers using the existing polymorphic `reviews()` relationship to keep behavior consistent.

### Description
- Added a new controller action `driverIndex` in `app/Http/Controllers/ReviewController.php` that loads the `Driver`, its reviews with `user`, computes the average rating via the model accessor, and returns a reviews view. 
- Registered a new route `Route::get('/driver/{id}/reviews', [ReviewController::class, 'driverIndex'])->name('reviews.driver');` in `routes/web.php`. 
- Added a new Blade view `resources/views/reviews/driver-index.blade.php` that reuses the existing reviews UI pattern (header, stars, review cards) and shows average rating and total reviews. 
- Added `getReviewsCountAttribute()` to `app/Models/Driver.php` and preserved `getAverageRatingAttribute()` computed from `$this->reviews()->avg('rating')` rounded to one decimal. 
- Added a **Reviews** button to the Guide listing rows (`resources/views/guide/index.blade.php`) linking to the existing guide reviews page and a **Reviews** button to the Driver approved listing rows (`resources/views/driver/approvedindex.blade.php`) linking to the new driver reviews page.
- No database schema changes, no changes to review storage or review business logic, and UI styling reuses existing review templates and classes.

### Testing
- Ran PHP syntax checks with `php -l` on `app/Http/Controllers/ReviewController.php` which reported no syntax errors. 
- Ran PHP syntax checks with `php -l` on `app/Models/Driver.php` which reported no syntax errors. 
- No automated feature or unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe14168e3c832fa5b008fcb83e8ac8)